### PR TITLE
[hermitcraft-agent] Add verification backlog strategy and analysis tool

### DIFF
--- a/prompts/verification-backlog-strategy.md
+++ b/prompts/verification-backlog-strategy.md
@@ -1,0 +1,127 @@
+# Verification Backlog Strategy
+
+Addresses the problem where task completion rate outpaces the verifier,
+leaving many tasks in `status=done` with `quality_score=null`. The
+supervisor cannot distinguish complete work from stalled work, causing
+redundant re-dispatches and wasted agent cycles.
+
+---
+
+## Root Cause
+
+The daemon verifies ≤ 3 tasks per 30-second cycle. If agents complete
+tasks faster than that, the backlog grows unboundedly. Once a task has
+been `done` but unverified for multiple cycles, the supervisor may
+re-dispatch it — producing duplicate work and false failure signals.
+
+---
+
+## Recommended Fix: Decoupled Verification Sub-Loop
+
+Run verification as a **separate higher-frequency loop** independent of
+the main 30-second daemon cycle.
+
+```
+main daemon (30s cycle)
+│
+├── dispatch new tasks
+├── run supervisor analysis
+└── (no longer blocks on verification)
+
+verification loop (5s cycle, runs concurrently)
+│
+├── query: SELECT * FROM tasks WHERE status='done' AND quality_score IS NULL LIMIT 10
+├── for each task: call verifier, write quality_score + verification_status
+└── emit routing event if score < 0.5 (see rejection-routing.md)
+```
+
+**Why this is better than raising the per-cycle limit:**
+
+| Approach | Pros | Cons |
+|---|---|---|
+| Raise limit (3 → 10) | Simple config change | Still coupled to 30s cycle; burst completions still lag |
+| Decouple sub-loop | Continuously drains backlog; scales with completion rate | Slightly more complex; needs concurrency guard |
+
+The decoupled loop is preferred because it is self-regulating: if there
+are 0 unverified tasks, it sleeps cheaply. If there are 50, it processes
+10 per 5-second tick and clears the backlog in ~25 seconds.
+
+---
+
+## Implementation Notes
+
+### Concurrency Guard
+
+The verification loop must not double-verify the same task. Use an
+optimistic lock or status transition:
+
+```sql
+-- Claim a batch atomically
+UPDATE tasks
+SET verification_status = 'in_progress'
+WHERE id IN (
+    SELECT id FROM tasks
+    WHERE status = 'done'
+      AND quality_score IS NULL
+      AND verification_status IS NULL
+    LIMIT 10
+)
+RETURNING *;
+```
+
+### Batch Size Tuning
+
+| Tasks in backlog | Recommended batch | Expected clear time |
+|---|---|---|
+| < 10 | 5 | 5–10s |
+| 10–50 | 10 | 25–50s |
+| > 50 | 15 | 50–75s |
+
+Start with batch size 10. Raise only if the verifier is consistently
+idle (backlog < batch size for 3+ consecutive ticks).
+
+### Fallback: Raise the Per-Cycle Limit
+
+If the decoupled loop is not feasible immediately, raise the per-cycle
+verification limit from 3 to **8** as an interim fix. This reduces lag
+under moderate load without requiring architectural changes.
+
+```python
+# orchestrator config — interim fix
+MAX_VERIFY_PER_CYCLE = 8  # was 3
+```
+
+Do not raise above 10 without also adding the concurrency guard, or
+multiple daemon instances may verify the same tasks simultaneously.
+
+---
+
+## Supervisor Behaviour Change
+
+Once the verification loop is decoupled, the supervisor should:
+
+1. **Never re-dispatch a task that is `status=done, verification_status=in_progress`.**
+   It is being verified — wait one more cycle.
+
+2. **Re-dispatch only if `verification_status` has been `in_progress` for
+   > 2 minutes** (the verifier itself may have stalled).
+
+3. **Use `quality_score IS NULL AND verification_status IS NULL AND
+   updated_at < NOW() - INTERVAL '5 minutes'`** as the signal for a
+   truly stalled/dropped task, not just `quality_score IS NULL`.
+
+---
+
+## Metrics to Track
+
+Add these to the supervisor's cycle summary to detect future backlogs early:
+
+```
+unverified_done_tasks: <count>        # target: < 5
+verification_lag_p50: <seconds>       # target: < 30s
+verification_lag_p95: <seconds>       # target: < 120s
+tasks_reverified: <count>             # target: 0 (dedup is working)
+```
+
+If `unverified_done_tasks` exceeds 10 for two consecutive cycles, emit
+an `infrastructure` alert — the verification loop may be down.

--- a/tests/test_verification_backlog.py
+++ b/tests/test_verification_backlog.py
@@ -1,0 +1,108 @@
+"""
+Tests for tools/verification_backlog.py
+Run with: python3 tests/test_verification_backlog.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tools.verification_backlog import analyse, format_report, BACKLOG_WARN_THRESHOLD, BACKLOG_CRIT_THRESHOLD
+
+
+def make_task(status="done", quality_score=None, verification_status=None, updated_at=None):
+    t = {"id": "test", "status": status}
+    if quality_score is not None:
+        t["quality_score"] = quality_score
+    if verification_status is not None:
+        t["verification_status"] = verification_status
+    if updated_at is not None:
+        t["updated_at"] = updated_at
+    return t
+
+
+passed = 0
+failed = 0
+
+
+def check(name, condition, detail=""):
+    global passed, failed
+    if condition:
+        print(f"  PASS {name}")
+        passed += 1
+    else:
+        print(f"  FAIL {name}" + (f": {detail}" if detail else ""))
+        failed += 1
+
+
+print("Summary counts:")
+
+tasks_mixed = (
+    [make_task(status="done", quality_score=None)] * 4 +            # 4 unverified
+    [make_task(status="done", quality_score=0.8)] * 3 +             # 3 verified
+    [make_task(status="done", verification_status="in_progress")] * 2 +  # 2 in-progress
+    [make_task(status="pending")] * 5                                # 5 not done
+)
+r = analyse(tasks_mixed)
+check("total_tasks", r["summary"]["total_tasks"] == 14)
+check("done_tasks", r["summary"]["done_tasks"] == 9)
+check("unverified_done", r["summary"]["unverified_done"] == 4)
+check("in_progress_verification", r["summary"]["in_progress_verification"] == 2)
+check("verified_done", r["summary"]["verified_done"] == 3)
+
+
+print("Severity thresholds:")
+
+ok_tasks = [make_task(quality_score=None)] * (BACKLOG_WARN_THRESHOLD - 1)
+check("ok severity", analyse(ok_tasks)["severity"] == "ok")
+check("ok exit code", analyse(ok_tasks)["exit_code"] == 0)
+
+warn_tasks = [make_task(quality_score=None)] * BACKLOG_WARN_THRESHOLD
+check("elevated severity", analyse(warn_tasks)["severity"] == "elevated")
+check("elevated exit code", analyse(warn_tasks)["exit_code"] == 1)
+
+crit_tasks = [make_task(quality_score=None)] * BACKLOG_CRIT_THRESHOLD
+check("critical severity", analyse(crit_tasks)["severity"] == "critical")
+check("critical exit code", analyse(crit_tasks)["exit_code"] == 2)
+
+
+print("In-progress tasks excluded from unverified:")
+
+in_prog = [make_task(verification_status="in_progress")] * 3
+check("in-progress not counted as unverified", analyse(in_prog)["summary"]["unverified_done"] == 0)
+
+verified = [make_task(quality_score=0.9)] * 3
+check("verified not counted as unverified", analyse(verified)["summary"]["unverified_done"] == 0)
+
+
+print("Lag calculation:")
+
+from datetime import datetime, timezone, timedelta
+old_ts = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+lag_tasks = [make_task(quality_score=None, updated_at=old_ts)] * 3
+r_lag = analyse(lag_tasks)
+check("lag p50 populated", r_lag["lag_seconds"]["p50"] is not None)
+check("lag p50 >= 100s", r_lag["lag_seconds"]["p50"] >= 100)
+
+no_ts_tasks = [make_task(quality_score=None)] * 3
+check("lag null when no updated_at", analyse(no_ts_tasks)["lag_seconds"]["p50"] is None)
+
+
+print("Empty input:")
+
+check("empty list returns ok", analyse([])["severity"] == "ok")
+check("empty list exit code 0", analyse([])["exit_code"] == 0)
+
+
+print("Format report:")
+
+r_fmt = analyse([make_task(quality_score=None)] * 12)
+report_str = format_report(r_fmt)
+check("report contains severity", "CRITICAL" in report_str)
+check("report contains recommendation", "Recommendation:" in report_str)
+check("report contains count", "12" in report_str)
+
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(0 if failed == 0 else 1)

--- a/tools/verification_backlog.py
+++ b/tools/verification_backlog.py
@@ -1,0 +1,169 @@
+"""
+verification_backlog.py
+
+Analyses a JSON task dump and reports the current verification backlog:
+  - unverified done tasks (quality_score=null, status=done)
+  - verification lag distribution
+  - recommendations based on backlog size
+
+Usage:
+    python tools/verification_backlog.py --tasks tasks.json
+    python tools/verification_backlog.py --tasks tasks.json --json
+    echo '[{"id":"abc","status":"done","quality_score":null}]' | \\
+        python tools/verification_backlog.py --stdin
+
+Exit codes:
+    0  — backlog within acceptable range (< 5 unverified tasks)
+    1  — backlog elevated (5-9 unverified tasks); consider raising batch size
+    2  — backlog critical (>= 10 unverified tasks); decouple verification loop
+    3  — unexpected error
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+
+BACKLOG_WARN_THRESHOLD = 5    # exit 1
+BACKLOG_CRIT_THRESHOLD = 10   # exit 2
+
+
+def analyse(tasks: list) -> dict:
+    """
+    Accepts a list of task dicts and returns a backlog analysis report.
+    Expected task fields (all optional except 'status'):
+        id, status, quality_score, verification_status, updated_at (ISO8601)
+    """
+    total = len(tasks)
+    done = [t for t in tasks if t.get("status") == "done"]
+    unverified = [
+        t for t in done
+        if t.get("quality_score") is None
+        and t.get("verification_status") not in ("in_progress", "verified")
+    ]
+    in_progress_verification = [
+        t for t in done
+        if t.get("verification_status") == "in_progress"
+    ]
+    verified = [t for t in done if t.get("quality_score") is not None]
+
+    # Compute lag for tasks that have updated_at
+    now = datetime.now(timezone.utc)
+    lags = []
+    for t in unverified:
+        updated = t.get("updated_at")
+        if updated:
+            try:
+                dt = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+                lags.append((now - dt).total_seconds())
+            except ValueError:
+                pass
+
+    lags.sort()
+    lag_p50 = lags[len(lags) // 2] if lags else None
+    lag_p95 = lags[int(len(lags) * 0.95)] if lags else None
+    lag_max = lags[-1] if lags else None
+
+    unverified_count = len(unverified)
+    if unverified_count >= BACKLOG_CRIT_THRESHOLD:
+        severity = "critical"
+        recommendation = (
+            f"Backlog is critical ({unverified_count} unverified tasks). "
+            "Decouple verification into a higher-frequency sub-loop running "
+            "every 5s with batch size 10. See prompts/verification-backlog-strategy.md."
+        )
+        exit_code = 2
+    elif unverified_count >= BACKLOG_WARN_THRESHOLD:
+        severity = "elevated"
+        recommendation = (
+            f"Backlog is elevated ({unverified_count} unverified tasks). "
+            "Raise per-cycle verification limit from 3 to 8 as an interim fix."
+        )
+        exit_code = 1
+    else:
+        severity = "ok"
+        recommendation = (
+            f"Backlog is within acceptable range ({unverified_count} unverified tasks)."
+        )
+        exit_code = 0
+
+    return {
+        "summary": {
+            "total_tasks": total,
+            "done_tasks": len(done),
+            "unverified_done": unverified_count,
+            "in_progress_verification": len(in_progress_verification),
+            "verified_done": len(verified),
+        },
+        "lag_seconds": {
+            "p50": round(lag_p50, 1) if lag_p50 is not None else None,
+            "p95": round(lag_p95, 1) if lag_p95 is not None else None,
+            "max": round(lag_max, 1) if lag_max is not None else None,
+        },
+        "severity": severity,
+        "recommendation": recommendation,
+        "exit_code": exit_code,
+    }
+
+
+def format_report(report: dict) -> str:
+    s = report["summary"]
+    lag = report["lag_seconds"]
+    lines = [
+        f"Verification Backlog Report",
+        f"  Total tasks:              {s['total_tasks']}",
+        f"  Done (total):             {s['done_tasks']}",
+        f"  Unverified done:          {s['unverified_done']}",
+        f"  Verification in-progress: {s['in_progress_verification']}",
+        f"  Verified done:            {s['verified_done']}",
+        f"  Lag p50:  {lag['p50']}s" if lag["p50"] is not None else "  Lag p50:  n/a",
+        f"  Lag p95:  {lag['p95']}s" if lag["p95"] is not None else "  Lag p95:  n/a",
+        f"  Lag max:  {lag['max']}s" if lag["max"] is not None else "  Lag max:  n/a",
+        f"",
+        f"Severity: {report['severity'].upper()}",
+        f"Recommendation: {report['recommendation']}",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    try:
+        parser = argparse.ArgumentParser(
+            description="Analyse verification backlog from a JSON task dump."
+        )
+        source = parser.add_mutually_exclusive_group(required=True)
+        source.add_argument("--tasks", help="Path to JSON file containing task list")
+        source.add_argument("--stdin", action="store_true", help="Read JSON from stdin")
+        parser.add_argument("--json", action="store_true", dest="as_json",
+                            help="Output as JSON")
+        args = parser.parse_args()
+
+        if args.stdin:
+            raw = sys.stdin.read()
+        else:
+            with open(args.tasks) as f:
+                raw = f.read()
+
+        tasks = json.loads(raw)
+        if not isinstance(tasks, list):
+            raise ValueError("Input must be a JSON array of task objects")
+
+        report = analyse(tasks)
+        exit_code = report["exit_code"]
+
+        if args.as_json:
+            print(json.dumps(report, indent=2))
+        else:
+            print(format_report(report))
+
+        sys.exit(exit_code)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"[verification_backlog] unexpected error: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #19

## Summary

- **`prompts/verification-backlog-strategy.md`**: documents the root cause (3-task/30s limit can't keep pace), recommends decoupling verification into a dedicated 5s sub-loop with batch size 10, provides a concurrency guard SQL pattern, a tuning table for batch size vs backlog size, an interim fix (raise limit to 8), and updated supervisor rules to stop re-dispatching tasks that are `verification_status=in_progress`
- **`tools/verification_backlog.py`**: reads a JSON task dump, counts unverified-done tasks, computes lag p50/p95/max, emits severity `ok`/`elevated`/`critical` with a concrete recommendation, exits 0/1/2 for shell pipeline use
- **`tests/test_verification_backlog.py`**: 21 tests covering summary counts, severity thresholds, in-progress exclusion, lag calculation, empty input, and report formatting

## Test plan

- [ ] `echo '[{"status":"done"}]' | python3 tools/verification_backlog.py --stdin` → exit 0, severity OK
- [ ] Pipe 10 unverified tasks → exit 2, severity CRITICAL, recommends decoupled loop
- [ ] Pipe 5 unverified tasks → exit 1, severity ELEVATED, recommends raising limit to 8
- [ ] Verify all 21 tests pass: `python3 tests/test_verification_backlog.py`