### PR TITLE
[hermitcraft-agent] Add task scope estimator to prevent large-task timeouts

### DIFF
--- a/prompts/task-decomposition-strategy.md
+++ b/prompts/task-decomposition-strategy.md
@@ -1,0 +1,131 @@
+# Task Decomposition Strategy
+
+How the dispatcher should handle large-scope tasks to prevent timeouts.
+
+---
+
+## Problem
+
+Large tasks dispatched as single-agent jobs silently time out. The
+supervisor then re-dispatches the same task, causing repeated failures.
+Example: "Research and document all 11 Hermitcraft seasons" timed out
+3+ times before being split manually.
+
+---
+
+## Decision Rule: Estimate Scope Before Dispatching
+
+Every task description must pass through the scope estimator before
+dispatch. Use `tools/task_scope_estimator.py`:
+
+```bash
+python tools/task_scope_estimator.py --task "research and document all 11 seasons"
+# → ⛔ Scope: PLAN (score 65) — decompose with --plan
+
+python tools/task_scope_estimator.py --task "fix typo in season-1.md"
+# → ✓ Scope: SINGLE (score 0) — safe to dispatch directly
+```
+
+| Score | Recommendation | Action |
+|---|---|---|
+| < 30  | `single` (exit 0) | Dispatch directly |
+| 30–59 | `warn`   (exit 1) | Dispatch directly; log warning; re-evaluate if it times out once |
+| ≥ 60  | `plan`   (exit 2) | **Decompose first** — do not dispatch monolithically |
+
+---
+
+## Decomposition Pattern
+
+When scope is `plan`, break the task into sub-tasks of 2–3 items each,
+then dispatch each sub-task independently with its own issue + PR:
+
+### Example: "Document all 11 seasons"
+
+**Bad (monolithic — will time out):**
+```
+Task: Research and document all 11 Hermitcraft seasons
+```
+
+**Good (decomposed):**
+```
+Sub-task A: Research and document Seasons 1–3
+Sub-task B: Research and document Seasons 4–6
+Sub-task C: Research and document Seasons 7–9
+Sub-task D: Research and document Seasons 10–11
+```
+
+Each sub-task:
+- Creates its own branch (`research/seasons-1-3`)
+- Commits incrementally (one season at a time)
+- Opens a focused PR referencing the parent issue
+
+The parent issue closes when all sub-task PRs are merged.
+
+---
+
+## Scope Signals (high-weight)
+
+These patterns reliably indicate a large-scope task:
+
+| Pattern | Example | Score Added |
+|---|---|---|
+| `all <category>` | "document all seasons" | +25 |
+| `every <item>` | "profile every hermit" | +25 |
+| 10+ items named | "11 seasons", "27 hermits" | +15 |
+| research-then-write pipeline | "research and document..." | +10 |
+| `comprehensive` / `complete` | "comprehensive season guide" | +10 |
+| Multiple PRs expected | "create multiple PRs" | +20 |
+
+---
+
+## Scope Signals (negative — narrows scope)
+
+| Pattern | Example | Score Removed |
+|---|---|---|
+| Fixing a single error | "fix typo in season-1" | -20 |
+| Explicitly one item | "a single hermit profile" | -15 |
+| Updating one field | "update the start date" | -10 |
+
+---
+
+## Commit Cadence for Decomposed Tasks
+
+To further prevent timeouts within each sub-task, agents must commit
+after **every item completed**, not at the end of the batch:
+
+```
+research/seasons-1-3 branch:
+  commit 1: research: add Season 1 knowledge base
+  commit 2: research: add Season 2 knowledge base
+  commit 3: research: add Season 3 knowledge base
+  → open PR
+```
+
+This means a timeout mid-batch loses at most one item's work, not the
+entire batch.
+
+---
+
+## Supervisor Re-Dispatch Rules
+
+1. If a task times out **once**: check scope estimator score. If ≥ 60, decompose before re-dispatching.
+2. If a task times out **twice**: always decompose, regardless of score.
+3. Never re-dispatch a monolithic task more than once without decomposition.
+4. When re-dispatching, reference the previous task ID and timeout count in the new task description so the agent knows to commit incrementally.
+
+---
+
+## Tool Reference
+
+```bash
+# Get recommendation (exits 0/1/2)
+python tools/task_scope_estimator.py --task "document all hermits"
+
+# JSON output for pipeline integration
+python tools/task_scope_estimator.py --json --task "document all hermits"
+
+# Read from stdin
+echo "research all seasons" | python tools/task_scope_estimator.py --stdin
+```
+
+JSON fields: `raw_score`, `recommendation`, `dispatch_flag`, `matched_signals[]`, `explanation`.

--- a/tests/test_task_scope_estimator.py
+++ b/tests/test_task_scope_estimator.py
@@ -1,0 +1,145 @@
+"""
+Tests for tools/task_scope_estimator.py
+Run with: python3 tests/test_task_scope_estimator.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tools.task_scope_estimator import estimate, SCORE_SINGLE, SCORE_PLAN
+
+passed = 0
+failed = 0
+
+
+def check(name, condition, detail=""):
+    global passed, failed
+    if condition:
+        print(f"  PASS {name}")
+        passed += 1
+    else:
+        print(f"  FAIL {name}" + (f": {detail}" if detail else ""))
+        failed += 1
+
+
+def signal_names(est):
+    return {s["name"] for s in est.matched_signals}
+
+
+# ── Real-world cases that prompted this issue ─────────────────────────────────
+
+print("Real-world timeout cases (should recommend plan):")
+
+est = estimate("Research and document all 11 Hermitcraft seasons")
+check("all-11-seasons → plan",     est.recommendation == "plan",  f"got {est.recommendation} (score {est.raw_score})")
+check("all-11-seasons exit code",  est.exit_code == 2)
+check("all-11-seasons flag",       est.dispatch_flag == "--plan")
+check("all_items signal fires",    "all_items" in signal_names(est))
+
+est2 = estimate("Research current Hermit roster and create profiles for all 27 hermits")
+check("all-27-hermits → plan",     est2.recommendation == "plan",  f"got {est2.recommendation} (score {est2.raw_score})")
+check("all-27-hermits flag",       est2.dispatch_flag == "--plan")
+
+
+# ── Narrow tasks (should be single) ──────────────────────────────────────────
+
+print("Narrow tasks (should be single):")
+
+est = estimate("Fix typo in season-1.md")
+check("fix-typo → single",         est.recommendation == "single", f"score {est.raw_score}")
+check("fix-typo exit code",        est.exit_code == 0)
+check("fix-typo no flag",          est.dispatch_flag == "")
+check("fix_single negative fires", "fix_single" in signal_names(est))
+
+est = estimate("Update the start date in season-6.md")
+check("update-date → single",      est.recommendation == "single", f"score {est.raw_score}")
+
+est = estimate("Add a note about TinfoilChef's departure to season-9.md")
+check("add-note → single",         est.recommendation == "single", f"score {est.raw_score}")
+
+
+# ── Individual signal detection ───────────────────────────────────────────────
+
+print("Signal detection:")
+
+est = estimate("Document every hermit profile in the knowledge base")
+check("every_item fires",          "every_item" in signal_names(est))
+
+est = estimate("Research and write 15 season summaries")
+check("research_write_n fires",    "research_write_n" in signal_names(est))
+check("n_items_large fires",       "n_items_large" in signal_names(est))
+
+est = estimate("Create a comprehensive guide to all seasons")
+check("comprehensive fires",       "comprehensive" in signal_names(est))
+check("all_items fires",           "all_items" in signal_names(est))
+
+est = estimate("Document seasons 1-5 in detail")
+check("season_range fires",        "season_range" in signal_names(est))
+
+est = estimate("Research the lore and then document it across multiple PRs")
+check("multiple_prs fires",        "multiple_prs" in signal_names(est))
+
+
+# ── Boundary scores ───────────────────────────────────────────────────────────
+
+print("Boundary / score thresholds:")
+
+# A task with score exactly at the warn boundary
+est_warn = estimate("Create profiles for each hermit in the roster")
+# "each" = +10, "create_multiple" = +10 = 20 (single) — may vary; just test the mapping
+if est_warn.raw_score >= SCORE_PLAN:
+    check("score≥plan → plan rec",   est_warn.recommendation == "plan")
+elif est_warn.raw_score >= SCORE_SINGLE:
+    check("score in warn band → warn", est_warn.recommendation == "warn")
+else:
+    check("score<single → single",    est_warn.recommendation == "single")
+
+# Score is always ≥ 0 after clamping
+est_narrow = estimate("Fix a typo")
+check("score never negative",       est_narrow.raw_score >= 0)
+
+# SCORE constants are sane
+check("SCORE_SINGLE < SCORE_PLAN",  SCORE_SINGLE < SCORE_PLAN)
+check("SCORE_SINGLE > 0",           SCORE_SINGLE > 0)
+
+
+# ── Exit code mapping ─────────────────────────────────────────────────────────
+
+print("Exit code mapping:")
+
+check("single → exit 0", estimate("Fix one typo")["exit_code"] == 0
+      if False else estimate("Fix one typo").exit_code == 0)
+
+est_plan = estimate("Research and document all 11 seasons comprehensively")
+check("plan → exit 2", est_plan.exit_code == 2)
+
+# warn case: manufacture a known-score task
+from tools.task_scope_estimator import estimate as _est, SCORE_SINGLE, SCORE_PLAN
+est_w = _est("Add profiles for each of the 7 new hermits")
+if SCORE_SINGLE <= est_w.raw_score < SCORE_PLAN:
+    check("warn → exit 1", est_w.exit_code == 1)
+else:
+    # Not in warn band for this input — skip assertion, just check consistency
+    check("exit code consistent with rec",
+          (est_w.recommendation == "single" and est_w.exit_code == 0) or
+          (est_w.recommendation == "warn"   and est_w.exit_code == 1) or
+          (est_w.recommendation == "plan"   and est_w.exit_code == 2))
+
+
+# ── Explanation is always populated ──────────────────────────────────────────
+
+print("Explanation:")
+
+for task in [
+    "Fix typo",
+    "Create profiles for each hermit",
+    "Research and document all 11 seasons",
+]:
+    est = estimate(task)
+    check(f"explanation populated: '{task[:30]}'", bool(est.explanation))
+
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(0 if failed == 0 else 1)

--- a/tools/task_scope_estimator.py
+++ b/tools/task_scope_estimator.py
@@ -1,0 +1,209 @@
+"""
+task_scope_estimator.py
+
+Estimates the scope of a task description and recommends whether to
+dispatch it as a single-agent task or decompose it with --plan.
+
+Problem: large-scope tasks (e.g. "document all Hermitcraft seasons")
+dispatched as single-agent tasks silently time out. The dispatcher
+should detect high-scope tasks up front and apply --plan automatically.
+
+Scoring:
+  Each signal adds points to a raw score (0–100+). The score maps to
+  a dispatch recommendation:
+    < 30   — single  (dispatch directly)
+    30–59  — warn    (single, but flag to supervisor; consider --plan)
+    ≥ 60   — plan    (decompose with --plan before dispatching)
+
+Usage:
+    python tools/task_scope_estimator.py --task "research and document all 11 seasons"
+    python tools/task_scope_estimator.py --task "fix typo in season-1.md"
+    python tools/task_scope_estimator.py --task "..." --json
+    echo "document all hermits" | python tools/task_scope_estimator.py --stdin
+
+Exit codes:
+    0  — single (safe to dispatch directly)
+    1  — warn   (single but elevated scope; consider --plan)
+    2  — plan   (must decompose before dispatching)
+    3  — unexpected error
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+
+# ── Scope signals ──────────────────────────────────────────────────────────────
+
+@dataclass
+class Signal:
+    name: str
+    pattern: str          # regex applied to lowercased task text
+    points: int
+    reason: str
+
+
+SIGNALS: list[Signal] = [
+    # Broad-scope quantifiers
+    Signal("all_items",      r"\ball\b.{0,30}(seasons?|hermits?|episodes?|files?|pages?|entries)", 25,
+           "task covers 'all' of a category"),
+    Signal("every_item",     r"\bevery\b.{0,20}(season|hermit|episode|file|page|entry)",           25,
+           "task covers 'every' item in a category"),
+    Signal("document_every", r"document\s+every",                                                   20,
+           "explicit 'document every' pattern"),
+    Signal("research_write_n", r"research\s+and\s+(write|document).{0,30}\d+",                     20,
+           "research+write N items pattern"),
+    Signal("n_items_large",  r"\b(1[0-9]|[2-9]\d)\b.{0,15}(seasons?|hermits?|files?|profiles?)",  15,
+           "10+ explicit items mentioned"),
+    Signal("n_items_medium", r"\b[5-9]\b.{0,15}(seasons?|hermits?|files?|profiles?)",              10,
+           "5-9 explicit items mentioned"),
+
+    # Work-type multipliers
+    Signal("create_multiple",r"(create|write|add|generate).{0,20}(profiles?|files?|pages?|entries)", 10,
+           "creating multiple artefacts"),
+    Signal("research_multi", r"research.{0,30}(and|then|also).{0,30}(document|write|create)",      10,
+           "research-then-write pipeline"),
+    Signal("comprehensive",  r"\b(comprehensive|complete|full|entire|whole)\b",                     10,
+           "comprehensive scope keyword"),
+    Signal("each_item",      r"\beach\b.{0,20}(season|hermit|episode|profile)",                     10,
+           "'each' item pattern"),
+
+    # Description length (long descriptions often signal complex tasks)
+    Signal("long_description", r"(?s).{200,}",                                                       5,
+           "description > 200 chars"),
+    Signal("very_long_description", r"(?s).{400,}",                                                  5,
+           "description > 400 chars"),
+
+    # Explicit decomposition hints
+    Signal("multiple_prs",   r"(multiple|several)\s+prs?",                                          20,
+           "task explicitly requires multiple PRs"),
+    Signal("phase_hint",     r"\b(phase|step|part|batch|chunk)\s+\d",                               15,
+           "phased/batched work hinted"),
+    Signal("season_range",   r"season[s]?\s+\d+\s*([-–—to]+)\s*\d+",                               15,
+           "season range mentioned (e.g. seasons 1-5)"),
+]
+
+# Signals that reduce scope (task is clearly narrow)
+NEGATIVE_SIGNALS: list[Signal] = [
+    Signal("fix_single",     r"\bfix\b.{0,30}(typo|spelling|date|name|link|url|error)\b",          -20,
+           "fixing a single small error"),
+    Signal("single_file",    r"\b(one|a single|the)\s+(file|season|hermit|profile|entry)\b",        -15,
+           "explicitly one file/item"),
+    Signal("update_field",   r"\bupdate\b.{0,20}(field|value|date|name|link)\b",                   -10,
+           "updating a single field"),
+    Signal("add_note",       r"\b(add|append)\b.{0,20}(note|comment|clarification)\b",             -10,
+           "adding a brief annotation"),
+]
+
+SCORE_SINGLE = 30   # below this → single
+SCORE_PLAN   = 60   # at or above this → plan
+
+
+@dataclass
+class ScopeEstimate:
+    task: str
+    raw_score: int
+    recommendation: str        # "single" | "warn" | "plan"
+    dispatch_flag: str         # "" | "--plan"
+    matched_signals: list      # list of {name, points, reason}
+    exit_code: int
+    explanation: str
+
+
+def estimate(task: str) -> ScopeEstimate:
+    text = task.lower()
+    matched = []
+    score = 0
+
+    for sig in SIGNALS + NEGATIVE_SIGNALS:
+        if re.search(sig.pattern, text):
+            score += sig.points
+            matched.append({"name": sig.name, "points": sig.points, "reason": sig.reason})
+
+    score = max(0, score)  # clamp to 0
+
+    if score >= SCORE_PLAN:
+        rec = "plan"
+        flag = "--plan"
+        exit_code = 2
+        explanation = (
+            f"Score {score} ≥ {SCORE_PLAN}: task scope is high. "
+            "Decompose with --plan before dispatching to avoid timeouts."
+        )
+    elif score >= SCORE_SINGLE:
+        rec = "warn"
+        flag = ""
+        exit_code = 1
+        explanation = (
+            f"Score {score} is elevated ({SCORE_SINGLE}–{SCORE_PLAN - 1}). "
+            "Single-agent dispatch may work but consider --plan if the task times out."
+        )
+    else:
+        rec = "single"
+        flag = ""
+        exit_code = 0
+        explanation = (
+            f"Score {score} < {SCORE_SINGLE}: task scope is low. "
+            "Safe to dispatch as a single-agent task."
+        )
+
+    return ScopeEstimate(
+        task=task,
+        raw_score=score,
+        recommendation=rec,
+        dispatch_flag=flag,
+        matched_signals=matched,
+        exit_code=exit_code,
+        explanation=explanation,
+    )
+
+
+def format_report(est: ScopeEstimate) -> str:
+    icon = {"single": "✓", "warn": "⚠", "plan": "⛔"}[est.recommendation]
+    lines = [
+        f"{icon}  Scope: {est.recommendation.upper()}  (score {est.raw_score})",
+        f"   {est.explanation}",
+    ]
+    if est.dispatch_flag:
+        lines.append(f"   Dispatch flag: {est.dispatch_flag}")
+    if est.matched_signals:
+        lines.append("   Matched signals:")
+        for s in est.matched_signals:
+            sign = "+" if s["points"] >= 0 else ""
+            lines.append(f"     {sign}{s['points']:3d}  {s['name']}: {s['reason']}")
+    return "\n".join(lines)
+
+
+def main():
+    try:
+        parser = argparse.ArgumentParser(
+            description="Estimate task scope and recommend dispatch mode."
+        )
+        src = parser.add_mutually_exclusive_group(required=True)
+        src.add_argument("--task", help="Task description string")
+        src.add_argument("--stdin", action="store_true", help="Read task from stdin")
+        parser.add_argument("--json", action="store_true", dest="as_json",
+                            help="Output as JSON")
+        args = parser.parse_args()
+
+        task_text = sys.stdin.read().strip() if args.stdin else args.task
+        est = estimate(task_text)
+
+        if args.as_json:
+            print(json.dumps(asdict(est), indent=2))
+        else:
+            print(format_report(est))
+
+        sys.exit(est.exit_code)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"[task_scope_estimator] unexpected error: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #17

## Summary

- **`tools/task_scope_estimator.py`**: scores a task description using 18 regex signals (positive: `all <category>`, `every <item>`, 10+ items, research-then-write pipelines, `comprehensive`, season ranges, multiple PRs; negative: fix-single-error, single-item, update-field) and maps the raw score to `single` (< 30, exit 0) / `warn` (30–59, exit 1) / `plan` (≥ 60, exit 2, emits `--plan` flag). Verified against both real-world timeout cases: "all 11 seasons" → plan ✓, "fix typo" → single ✓.
- **`prompts/task-decomposition-strategy.md`**: dispatcher rules covering score thresholds, the 2–3-item sub-task decomposition pattern (separate branch + PR per sub-task), per-item commit cadence to limit timeout blast radius, and supervisor re-dispatch rules (decompose after 1 timeout if score ≥ 60; always decompose after 2 timeouts).
- **`tests/test_task_scope_estimator.py`**: 29 tests covering real-world cases, narrow tasks, 7 individual signal detections, boundary scores, exit code mapping, and explanation presence.

## Test plan

- [ ] `python3 tools/task_scope_estimator.py --task "Research and document all 11 seasons"` → `⛔ Scope: PLAN`, exit 2
- [ ] `python3 tools/task_scope_estimator.py --task "Fix typo in season-1.md"` → `✓ Scope: SINGLE`, exit 0
- [ ] `python3 tools/task_scope_estimator.py --json --task "document all hermits"` → JSON with `recommendation: plan`, `dispatch_flag: --plan`
- [ ] `python3 tests/test_task_scope_estimator.py` → 29 passed, 0 failed