### PR TITLE
[hermitcraft-agent] Add verifier score adjuster and blocked status for infra failures

### DIFF
--- a/prompts/verifier-prompt.md
+++ b/prompts/verifier-prompt.md
@@ -1,0 +1,145 @@
+# Verifier Prompt
+
+Instructions for scoring a completed agent task and assigning a
+verification status.
+
+---
+
+## Three-Status Model
+
+Every completed task receives one of three statuses — **not two**:
+
+| Status | Meaning | Next action |
+|---|---|---|
+| `verified` | Score ≥ 0.75, no infrastructure blocker | Accept; merge PR / close issue |
+| `rejected` | Score < 0.75, agent-caused shortfall | Dispatch revision guidance immediately |
+| `blocked`  | Infrastructure blocker detected | Escalate to orchestrator; do NOT re-dispatch agent |
+
+The `blocked` status is distinct from `rejected`. A blocked task may
+have been completed correctly by the agent — the failure is in the
+environment, not the work.
+
+---
+
+## Step 1 — Scan for Infrastructure Blockers First
+
+Before scoring, read the task result and check for any of the following
+signals. If found, the task is `blocked` regardless of outcome:
+
+- Authentication / credentials: `gh CLI not authenticated`, `GITHUB_TOKEN not set`, `permission denied`
+- Missing tools: `command not found`, `gh: not found`
+- Container / environment limits: `container`, `env var not set`, `no such file or directory`
+- Network failures: `connection refused`, `network timeout`, `DNS`, `rate limit`, `quota exceeded`
+- Secret management: `SSH key`, `certificate`, `secret not available`
+
+**If a blocker is present:**
+1. Note the exact signal in your verification notes.
+2. Score *only the agent's portion* of the work (see Step 2b).
+3. Set status = `blocked`.
+4. Do not penalise the score for the infrastructure step the agent could not complete.
+
+Use `tools/verifier_score_adjuster.py` to compute the adjusted score:
+
+```bash
+python tools/verifier_score_adjuster.py \
+  --score <raw_score> \
+  --result "...task result text..."
+```
+
+---
+
+## Step 2a — Standard Scoring (no blocker)
+
+Evaluate the task against its acceptance criteria. Consider:
+
+| Dimension | Weight |
+|---|---|
+| Correctness (facts, logic, data) | 40% |
+| Completeness (all required items present) | 30% |
+| Format / structure (YAML, markdown, tests pass) | 20% |
+| Commit hygiene (message, branch, references issue) | 10% |
+
+Score 0.0–1.0.  Accept at ≥ 0.75; reject below.
+
+---
+
+## Step 2b — Adjusted Scoring (blocker present)
+
+When an infra blocker is confirmed, the observable outcome
+(e.g. no PR created) reflects the environment, not the agent.
+
+Score only what the agent controlled:
+- Were the files written correctly? (correctness + completeness + format)
+- Were commits made properly?
+- Did the agent explicitly flag the blocker in its output?
+
+Exclude from scoring:
+- Whether the PR was created (requires `gh` auth)
+- Whether remote push succeeded (requires `GH_TOKEN`)
+- Any step after the blocker was hit
+
+The adjuster applies a 25% infra weight correction automatically:
+`adjusted_score = min(raw_score / 0.75, 1.0)`
+
+---
+
+## Step 3 — Write Verification Notes
+
+Notes must include:
+
+1. **Status**: `verified` / `rejected` / `blocked`
+2. **Score**: raw score (and adjusted score if blocked)
+3. **Evidence**: specific lines from the result that support the score
+4. **Blocker signal** (if blocked): exact matched pattern
+5. **Next action**: what the orchestrator should do
+
+### Example — blocked task
+
+```
+Status: blocked
+Raw score: 0.35 → adjusted: 0.47
+Blocker: "GITHUB_TOKEN not set in container" (matched: 'github[_ ]token')
+Evidence: Agent committed all 11 season files (46ea6ad, 7dda94c).
+          Push failed with: fatal: could not read Username — GH_TOKEN missing.
+Agent work: complete. Infrastructure work: blocked.
+Next action: inject GH_TOKEN into container; re-run push step only.
+             Do NOT re-dispatch full research task.
+```
+
+### Example — rejected task
+
+```
+Status: rejected
+Score: 0.45
+Evidence: Season 10 file lists TinfoilChef as returning member (left before S10).
+          Season 8 end date incorrect (2020 vs 2021).
+Next action: dispatch revision task with specific corrections.
+```
+
+### Example — verified task
+
+```
+Status: verified
+Score: 0.82
+Evidence: All 27 hermit profiles present with correct YAML frontmatter.
+          Tests pass. Branch pushed. PR opened with issue reference.
+Next action: approve and merge.
+```
+
+---
+
+## Quick Reference
+
+```bash
+# Adjust score for infra blocker (exits 0=verified, 1=rejected, 2=blocked)
+python tools/verifier_score_adjuster.py --score 0.35 \
+  --result "Committed all files. Push failed: GITHUB_TOKEN not set."
+
+# JSON output for pipeline
+python tools/verifier_score_adjuster.py --score 0.35 --json \
+  --result "..."
+
+# Also see:
+#   tools/rejection_classifier.py  — classify fixable vs infra-blocked
+#   prompts/rejection-routing.md   — routing decisions after rejection
+```

--- a/tests/test_verifier_score_adjuster.py
+++ b/tests/test_verifier_score_adjuster.py
@@ -1,0 +1,137 @@
+"""
+Tests for tools/verifier_score_adjuster.py
+Run with: python3 tests/test_verifier_score_adjuster.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tools.verifier_score_adjuster import (
+    adjust,
+    detect_blocker,
+    ACCEPT_THRESHOLD,
+    INFRA_WEIGHT,
+)
+
+passed = 0
+failed = 0
+
+
+def check(name, condition, detail=""):
+    global passed, failed
+    if condition:
+        print(f"  PASS {name}")
+        passed += 1
+    else:
+        print(f"  FAIL {name}" + (f": {detail}" if detail else ""))
+        failed += 1
+
+
+# ── Real-world cases from the issue ──────────────────────────────────────────
+
+print("Real-world cases (tasks 01KMC04C / 01KMC05Z):")
+
+# Task 01KMC05Z: score 0.35, push failed due to missing GH_TOKEN
+r = adjust(0.35, "All files committed. Push failed: GITHUB_TOKEN not set in container.")
+check("01KMC05Z → blocked",           r.status == "blocked")
+check("01KMC05Z exit code 2",         r.exit_code == 2)
+check("01KMC05Z blocker detected",    r.blocker_detected is True)
+check("01KMC05Z adjusted > raw",      r.adjusted_score > r.raw_score,
+      f"adjusted={r.adjusted_score}, raw={r.raw_score}")
+check("01KMC05Z adjusted <= 1.0",     r.adjusted_score <= 1.0)
+
+# Task 01KMC04C: score 0.45, same root cause
+r2 = adjust(0.45, "Committed all season files. gh push failed: not authenticated.")
+check("01KMC04C → blocked",           r2.status == "blocked")
+check("01KMC04C adjusted > raw",      r2.adjusted_score > r2.raw_score)
+
+
+# ── detect_blocker ────────────────────────────────────────────────────────────
+
+print("detect_blocker:")
+
+check("detects GITHUB_TOKEN",         detect_blocker("GITHUB_TOKEN not set") is not None)
+check("detects gh not authenticated", detect_blocker("gh CLI not authenticated") is not None)
+check("detects permission denied",    detect_blocker("Permission denied (publickey)") is not None)
+check("detects command not found",    detect_blocker("bash: gh: command not found") is not None)
+check("detects rate limit",           detect_blocker("API rate limit exceeded") is not None)
+check("detects connection refused",   detect_blocker("Connection refused") is not None)
+check("returns None for clean result",detect_blocker("All files written and pushed.") is None)
+check("case-insensitive",             detect_blocker("PERMISSION DENIED") is not None)
+
+
+# ── Adjusted score calculation ────────────────────────────────────────────────
+
+print("Score adjustment calculation:")
+
+# adjusted = min(raw / (1 - INFRA_WEIGHT), 1.0)
+import math
+blocker_text = "Push failed: GITHUB_TOKEN not set."
+
+r = adjust(0.35, blocker_text)
+expected = min(0.35 / (1 - INFRA_WEIGHT), 1.0)
+check("0.35 adjusted correctly",
+      math.isclose(r.adjusted_score, round(expected, 4), rel_tol=1e-4))
+
+r = adjust(0.45, blocker_text)
+expected = min(0.45 / (1 - INFRA_WEIGHT), 1.0)
+check("0.45 adjusted correctly",
+      math.isclose(r.adjusted_score, round(expected, 4), rel_tol=1e-4))
+
+# Score that would overflow 1.0 without cap
+r = adjust(0.90, blocker_text)
+check("adjusted score capped at 1.0", r.adjusted_score <= 1.0)
+check("raw_score preserved",          r.raw_score == 0.90)
+
+
+# ── No-blocker path ───────────────────────────────────────────────────────────
+
+print("No-blocker path:")
+
+r_ok = adjust(0.80, "All 11 season files written, pushed, PR opened.")
+check("0.80 clean → verified",        r_ok.status == "verified")
+check("0.80 exit code 0",             r_ok.exit_code == 0)
+check("0.80 no adjustment",           r_ok.adjusted_score == r_ok.raw_score)
+check("0.80 blocker_detected False",  r_ok.blocker_detected is False)
+check("0.80 matched_pattern None",    r_ok.matched_pattern is None)
+
+r_rej = adjust(0.60, "Season 10 member list is incorrect.")
+check("0.60 clean → rejected",        r_rej.status == "rejected")
+check("0.60 exit code 1",             r_rej.exit_code == 1)
+check("0.60 no adjustment",           r_rej.adjusted_score == r_rej.raw_score)
+
+# Exact threshold
+r_thresh = adjust(ACCEPT_THRESHOLD, "Work complete.")
+check(f"score={ACCEPT_THRESHOLD} → verified", r_thresh.status == "verified")
+
+r_below = adjust(ACCEPT_THRESHOLD - 0.01, "Work complete.")
+check(f"score={ACCEPT_THRESHOLD - 0.01:.2f} → rejected", r_below.status == "rejected")
+
+
+# ── blocked status always wins regardless of raw score ───────────────────────
+
+print("blocked status overrides score level:")
+
+for score in [0.10, 0.50, 0.80, 0.99]:
+    r = adjust(score, "Push failed: GITHUB_TOKEN not set.")
+    check(f"score={score} + blocker → blocked", r.status == "blocked",
+          f"got {r.status}")
+
+
+# ── Adjustment note is always populated ──────────────────────────────────────
+
+print("adjustment_note always populated:")
+
+for text, score in [
+    ("Push failed: GH_TOKEN missing.", 0.35),
+    ("Wrong facts in season file.", 0.50),
+    ("All work complete.", 0.85),
+]:
+    r = adjust(score, text)
+    check(f"note populated (score={score})", bool(r.adjustment_note))
+
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(0 if failed == 0 else 1)

--- a/tools/verifier_score_adjuster.py
+++ b/tools/verifier_score_adjuster.py
@@ -1,0 +1,182 @@
+"""
+verifier_score_adjuster.py
+
+Adjusts a raw verifier score when infrastructure blockers are detected
+in the task result text, and assigns one of three verification statuses:
+
+    verified   — score >= 0.75, no blocker
+    rejected   — score < 0.75, no blocker (agent error, can retry)
+    blocked    — infrastructure blocker detected regardless of score
+
+Problem: tasks 01KMC04C (0.45) and 01KMC05Z (0.35) were scored against
+the final observable outcome (no PR created) without accounting for the
+missing GH_TOKEN that prevented the push.  The agent completed all code
+work correctly — only the infra step failed.
+
+Adjustment logic:
+  1. Scan the result text for INFRA_PATTERNS (imported from rejection_classifier).
+  2. If a blocker is found:
+       a. Identify the blocker's contribution to the task (INFRA_WEIGHT).
+       b. Re-score only the agent's portion: adjusted = raw / (1 - INFRA_WEIGHT)
+          capped at 1.0.
+       c. Set status = 'blocked' regardless of the adjusted score.
+  3. If no blocker: status = 'verified' if score >= ACCEPT_THRESHOLD else 'rejected'.
+
+Usage:
+    python tools/verifier_score_adjuster.py --score 0.35 \\
+        --result "All files committed. gh push failed: GITHUB_TOKEN not set."
+
+    python tools/verifier_score_adjuster.py --score 0.35 \\
+        --result-file result.txt --json
+
+Exit codes:
+    0  — verified
+    1  — rejected  (agent should retry)
+    2  — blocked   (orchestrator must fix infra)
+    3  — unexpected error
+"""
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+# Import infra patterns from sibling module to keep detection logic in one place
+try:
+    from tools.rejection_classifier import INFRA_PATTERNS
+except ImportError:
+    # Allow running from repo root or tools/ directory
+    import os
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from tools.rejection_classifier import INFRA_PATTERNS
+
+# Score at or above which work is accepted (no blocker path)
+ACCEPT_THRESHOLD = 0.75
+
+# Fraction of a typical task that infra steps (push, PR creation) represent.
+# When a blocker prevents only this portion, we credit the agent for the rest.
+INFRA_WEIGHT = 0.25
+
+
+@dataclass
+class AdjustmentResult:
+    raw_score: float
+    adjusted_score: float
+    status: str                     # "verified" | "rejected" | "blocked"
+    blocker_detected: bool
+    matched_pattern: Optional[str]
+    adjustment_note: str
+    exit_code: int
+
+
+def detect_blocker(text: str) -> Optional[str]:
+    """Return the first matching INFRA_PATTERN found in text, or None."""
+    lower = text.lower()
+    for pattern in INFRA_PATTERNS:
+        if re.search(pattern, lower):
+            return pattern
+    return None
+
+
+def adjust(raw_score: float, result_text: str) -> AdjustmentResult:
+    matched = detect_blocker(result_text)
+
+    if matched:
+        # Re-score only the agent-controlled portion of the work.
+        # If infra accounts for INFRA_WEIGHT of the task, then:
+        #   raw_score = agent_score * (1 - INFRA_WEIGHT) + 0 * INFRA_WEIGHT
+        #   agent_score = raw_score / (1 - INFRA_WEIGHT)
+        agent_score = min(raw_score / (1 - INFRA_WEIGHT), 1.0)
+        note = (
+            f"Infrastructure blocker detected ('{matched}'). "
+            f"Raw score {raw_score:.2f} re-scored to {agent_score:.2f} "
+            f"after removing {INFRA_WEIGHT:.0%} infra weight. "
+            f"Status set to 'blocked' — do not re-dispatch agent; fix infra first."
+        )
+        return AdjustmentResult(
+            raw_score=raw_score,
+            adjusted_score=round(agent_score, 4),
+            status="blocked",
+            blocker_detected=True,
+            matched_pattern=matched,
+            adjustment_note=note,
+            exit_code=2,
+        )
+
+    # No blocker — standard accept/reject threshold
+    if raw_score >= ACCEPT_THRESHOLD:
+        note = f"Score {raw_score:.2f} >= {ACCEPT_THRESHOLD} threshold. Work accepted."
+        status, exit_code = "verified", 0
+    else:
+        note = (
+            f"Score {raw_score:.2f} < {ACCEPT_THRESHOLD} threshold and no infra blocker. "
+            f"Agent error — dispatch revision guidance."
+        )
+        status, exit_code = "rejected", 1
+
+    return AdjustmentResult(
+        raw_score=raw_score,
+        adjusted_score=raw_score,
+        status=status,
+        blocker_detected=False,
+        matched_pattern=None,
+        adjustment_note=note,
+        exit_code=exit_code,
+    )
+
+
+def format_report(r: AdjustmentResult) -> str:
+    icon = {"verified": "✓", "rejected": "✗", "blocked": "⚠"}[r.status]
+    lines = [
+        f"{icon}  Status: {r.status.upper()}",
+        f"   Raw score:      {r.raw_score:.2f}",
+    ]
+    if r.blocker_detected:
+        lines.append(f"   Adjusted score: {r.adjusted_score:.2f}  (infra portion removed)")
+        lines.append(f"   Blocker signal: {r.matched_pattern}")
+    lines.append(f"   Note: {r.adjustment_note}")
+    return "\n".join(lines)
+
+
+def main():
+    try:
+        parser = argparse.ArgumentParser(
+            description="Adjust verifier score for infrastructure blockers."
+        )
+        parser.add_argument("--score", type=float, required=True,
+                            help="Raw verifier score (0.0–1.0)")
+        src = parser.add_mutually_exclusive_group(required=True)
+        src.add_argument("--result", help="Task result text string")
+        src.add_argument("--result-file", help="Path to file containing result text")
+        src.add_argument("--stdin", action="store_true", help="Read result text from stdin")
+        parser.add_argument("--json", action="store_true", dest="as_json",
+                            help="Output as JSON")
+        args = parser.parse_args()
+
+        if args.stdin:
+            result_text = sys.stdin.read()
+        elif args.result_file:
+            with open(args.result_file) as f:
+                result_text = f.read()
+        else:
+            result_text = args.result
+
+        r = adjust(args.score, result_text)
+
+        if args.as_json:
+            print(json.dumps(asdict(r), indent=2))
+        else:
+            print(format_report(r))
+
+        sys.exit(r.exit_code)
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"[verifier_score_adjuster] unexpected error: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #16

## Summary

- **`tools/verifier_score_adjuster.py`**: detects infrastructure blockers in the task result text (re-using `INFRA_PATTERNS` from `rejection_classifier.py` — single source of truth), then re-scores only the agent-controlled portion of the work using `adjusted = min(raw / (1 - INFRA_WEIGHT), 1.0)` where `INFRA_WEIGHT = 0.25` (push + PR creation). Returns status `verified` / `rejected` / `blocked` with exit codes 0/1/2. Both motivating cases now correctly route: score 0.35 + "GITHUB_TOKEN not set" → `blocked` (adjusted 0.467); score 0.45 + "not authenticated" → `blocked` (adjusted 0.60).
- **`prompts/verifier-prompt.md`**: formalises the three-status model with a table, a blocker-scan-first step, scoring dimensions (correctness 40%, completeness 30%, format 20%, commits 10%), the adjusted-scoring formula with what to exclude (push success, PR creation), and worked example verification notes for all three statuses.
- **`tests/test_verifier_score_adjuster.py`**: 36 tests — real-world 0.35/0.45 cases, `detect_blocker` for 8 signal types, adjustment math at 0.35/0.45/0.90, no-blocker verified/rejected paths, exact threshold boundaries, `blocked` overrides score at 0.10/0.50/0.80/0.99, and note-always-populated checks.

## Test plan

- [ ] `python3 tools/verifier_score_adjuster.py --score 0.35 --result "Push failed: GITHUB_TOKEN not set."` → `⚠ Status: BLOCKED`, exit 2
- [ ] `python3 tools/verifier_score_adjuster.py --score 0.80 --result "All work complete, PR opened."` → `✓ Status: VERIFIED`, exit 0
- [ ] `python3 tools/verifier_score_adjuster.py --score 0.60 --result "Season 10 member list wrong."` → `✗ Status: REJECTED`, exit 1
- [ ] `python3 tools/verifier_score_adjuster.py --json --score 0.35 --result "GITHUB_TOKEN missing"` → JSON with `status: blocked`, `adjusted_score > raw_score`
- [ ] `python3 tests/test_verifier_score_adjuster.py` → 36 passed, 0 failed