### PR TITLE
[hermitcraft-agent] Add duplicate task detector to prevent redundant supervisor dispatches

### DIFF
--- a/prompts/supervisor-dispatch-rules.md
+++ b/prompts/supervisor-dispatch-rules.md
@@ -61,8 +61,16 @@ of the following are true:
    previous one (e.g. a decomposed sub-task vs the original monolithic task)
 
 If the previous task was `blocked` (infra failure), do **not** re-dispatch
-until the infrastructure issue is resolved.  Check `tools/rejection_classifier.py`
-to confirm the blocker has been removed.
+until the infrastructure issue is resolved.  Use `tools/rejection_classifier.py`
+(present in this repo, merged in PR #12) to confirm the blocker signal
+is no longer present in the environment before re-dispatching:
+
+```bash
+python tools/rejection_classifier.py \
+  --score 0.35 \
+  --notes "$(cat latest_task_result.txt)"
+# exits 0 (fixable/clear) or 1 (still infrastructure-blocked)
+```
 
 ---
 

--- a/tests/test_duplicate_task_detector.py
+++ b/tests/test_duplicate_task_detector.py
@@ -77,9 +77,9 @@ for status in ["dispatched", "in_progress", "in-progress", "running"]:
 
 # ── Recent completions block within window ────────────────────────────────────
 
-print("Recency window (done/rejected/blocked):")
+print("Recency window (done/failed/rejected/blocked):")
 
-for status in ["done", "completed", "rejected", "blocked", "verified"]:
+for status in ["done", "failed", "completed", "rejected", "blocked", "verified"]:
     task = {"id": "t1", "title": "Fix PR #10 merge conflict",
             "status": status, "source_ref": "pull/10",
             "updated_at": ago_iso(hours=1)}  # 1h ago — within 4h window
@@ -87,26 +87,29 @@ for status in ["done", "completed", "rejected", "blocked", "verified"]:
     check(f"status='{status}' recent → blocks dispatch", r.is_duplicate,
           f"got is_duplicate={r.is_duplicate}")
 
-# Stale completed task (beyond window) should NOT block
-stale_task = {
-    "id": "t1", "title": "Fix PR #10 merge conflict",
-    "status": "done", "source_ref": "pull/10",
-    "updated_at": ago_iso(hours=RECENCY_WINDOW_HOURS + 1)
-}
-r = check_duplicate("Fix PR #10 merge conflict", [stale_task], "pull/10")
-check("stale done task (beyond window) does NOT block", not r.is_duplicate,
-      f"got is_duplicate={r.is_duplicate}")
+# Stale completed/failed tasks (beyond window) should NOT block
+for stale_status in ["done", "failed"]:
+    stale_task = {
+        "id": "t1", "title": "Fix PR #10 merge conflict",
+        "status": stale_status, "source_ref": "pull/10",
+        "updated_at": ago_iso(hours=RECENCY_WINDOW_HOURS + 1)
+    }
+    r = check_duplicate("Fix PR #10 merge conflict", [stale_task], "pull/10")
+    check(f"stale {stale_status} task (beyond window) does NOT block", not r.is_duplicate,
+          f"got is_duplicate={r.is_duplicate}")
 
 
 # ── Source-ref extraction ─────────────────────────────────────────────────────
 
 print("extract_refs:")
 
-check("extracts #10",        "#10"       in extract_refs("Fix issue #10"))
-check("extracts pull/10",    "pull/10"   in extract_refs("see pull/10"))
-check("extracts issues/5",   "issues/5"  in extract_refs("issues/5 blocked"))
-check("extracts pr-10 → #10","#10"       in extract_refs("pr-10 fix"))
-check("no refs → empty set", extract_refs("nothing to see here") == set())
+check("extracts #10",                  "#10"      in extract_refs("Fix issue #10"))
+check("extracts pull/10",              "pull/10"  in extract_refs("see pull/10"))
+check("extracts issues/5 → issue/5",   "issue/5"  in extract_refs("issues/5 blocked"))
+check("extracts issue/5 → issue/5",    "issue/5"  in extract_refs("issue/5 blocked"))
+check("issues/N and issue/N match",    extract_refs("issues/5") & extract_refs("issue/5") != set())
+check("extracts pr-10 → #10",          "#10"      in extract_refs("pr-10 fix"))
+check("no refs → empty set",           extract_refs("nothing to see here") == set())
 check("multiple refs",       len(extract_refs("PR #10 and #12")) == 2)
 
 

--- a/tools/duplicate_task_detector.py
+++ b/tools/duplicate_task_detector.py
@@ -65,10 +65,15 @@ STOPWORDS = {
 }
 
 # Task statuses that block dispatch unconditionally (in-flight work).
+# Schema statuses: dispatched, in_progress.
+# "in-progress" and "running" are defensive aliases not in the schema.
 INFLIGHT_STATUSES = {"dispatched", "in_progress", "in-progress", "running"}
 
 # Task statuses that block dispatch only within the recency window.
-RECENT_STATUSES = {"done", "completed", "rejected", "blocked", "verified"}
+# Schema statuses: done, failed.
+# "completed", "rejected", "blocked", "verified" are defensive aliases
+# used by adjacent tools (verifier_score_adjuster, rejection_classifier).
+RECENT_STATUSES = {"done", "failed", "completed", "rejected", "blocked", "verified"}
 
 
 @dataclass
@@ -90,14 +95,20 @@ def extract_keywords(title: str) -> set:
 
 
 def extract_refs(text: str) -> set:
-    """Extract PR/issue/branch references from text (e.g. 'pull/10', '#10', 'pr-10')."""
+    """Extract PR/issue/branch references from text (e.g. 'pull/10', '#10', 'pr-10').
+
+    All issue variants ('issues/10', 'issue/10') are normalised to 'issue/N'
+    so they match each other regardless of pluralisation.
+    """
     refs = set()
     # GitHub-style: #10, PR #10, issue #10
     for m in re.finditer(r"#(\d+)", text.lower()):
         refs.add(f"#{m.group(1)}")
-    # URL-style: pull/10, issues/10
+    # URL-style: pull/10, issues/10, issue/10
+    # Normalise 'issues/N' → 'issue/N' for consistent matching.
     for m in re.finditer(r"(pull|issue[s]?)/(\d+)", text.lower()):
-        refs.add(f"{m.group(1)}/{m.group(2)}")
+        prefix = "issue" if m.group(1).startswith("issue") else m.group(1)
+        refs.add(f"{prefix}/{m.group(2)}")
     # Branch-style: pr-10, issue-10
     for m in re.finditer(r"(pr|issue)-(\d+)", text.lower()):
         refs.add(f"#{m.group(2)}")


### PR DESCRIPTION
Closes #15

## Summary

The supervisor dispatched 3–5 consecutive tasks for the same work (PR #10 merge conflicts: tasks 01KMBW90, 01KMBT19, 01KMC2EH; cheese-hater push failures: 01KMC04C, 01KMC2QZ, 01KMC2A9, 01KMC2GD) because each cycle saw unresolved state without checking for in-flight or recently-completed coverage.

- **`tools/duplicate_task_detector.py`**: checks a proposed task against existing tasks via (1) **source-ref matching** — extracts `#N`, `pull/N`, `issues/N`, `pr-N` refs from titles and `source_ref` fields; (2) **keyword overlap** — ≥ 60% of significant words must match (stopwords + short words excluded); blocks dispatch if an in-flight task (`dispatched`/`in_progress`) matches, or a completed/rejected task matches within the 4-hour recency window. Key correctness fix: if both sides have refs but they're *different* (`pull/5` vs `pull/10`), keyword matching is skipped to prevent false positives on shared generic terms like "merge conflict".
- **`prompts/supervisor-dispatch-rules.md`**: formalises the pre-dispatch duplicate check with a decision table, re-dispatch conditions (4h window expiry, infra fix confirmed, meaningfully different scope), in-flight grace period (wait 30min, watchlist 30–120min, mark timed-out >120min), `source_ref` population guidance, and supervisor cycle pseudocode.
- **`tests/test_duplicate_task_detector.py`**: 44 tests — real-world PR #10 and cheese-hater cases, all 4 in-flight statuses, 5 completion statuses within window, stale task allowance, `extract_refs` (6 cases), `extract_keywords` (7 cases), keyword overlap threshold, distinct-ref skip, `is_recent` (4 cases), result field shape.

## Test plan

- [ ] `python3 tools/duplicate_task_detector.py --title "Fix PR #10 merge conflict" --source-ref "pull/10" --tasks tasks.json` → `⛔ DUPLICATE`, exit 1 (when a task for pull/10 is dispatched)
- [ ] Same with a task for `pull/5` → `✓ SAFE TO DISPATCH`, exit 0
- [ ] `--json` output → valid JSON with `is_duplicate`, `match_type`, `keyword_overlap`
- [ ] `python3 tests/test_duplicate_task_detector.py` → 44 passed, 0 failed