### PR TITLE
[hermitcraft-agent] Add Hermitcraft trivia quiz CLI with 55 questions

### DIFF
--- a/knowledge/trivia/questions.json
+++ b/knowledge/trivia/questions.json
@@ -1,0 +1,557 @@
+[
+  {
+    "id": "q001",
+    "question": "Who founded the Hermitcraft server?",
+    "options": ["Xisumavoid", "Generikb", "BdoubleO100", "Keralis"],
+    "answer": "Generikb",
+    "difficulty": "easy",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-1.md"
+  },
+  {
+    "id": "q002",
+    "question": "In what year was Hermitcraft founded?",
+    "options": ["2010", "2011", "2012", "2013"],
+    "answer": "2012",
+    "difficulty": "easy",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-1.md"
+  },
+  {
+    "id": "q003",
+    "question": "Who became server administrator after Generikb left?",
+    "options": ["BdoubleO100", "Mumbo Jumbo", "Xisumavoid", "EthosLab"],
+    "answer": "Xisumavoid",
+    "difficulty": "easy",
+    "category": "hermits",
+    "source": "knowledge/seasons/season-1.md"
+  },
+  {
+    "id": "q004",
+    "question": "Which hermit joined Hermitcraft in Season 6 and became its most-subscribed creator?",
+    "options": ["GeminiTay", "Grian", "SmallishBeans", "Skizzleman"],
+    "answer": "Grian",
+    "difficulty": "easy",
+    "category": "hermits",
+    "source": "knowledge/hermits/grian.md"
+  },
+  {
+    "id": "q005",
+    "question": "What is the name of TangoTek's famous dungeon-crawler card game built in Hermitcraft?",
+    "options": ["TangoTown", "Decked Out", "The Tangler", "Card Kingdom"],
+    "answer": "Decked Out",
+    "difficulty": "easy",
+    "category": "lore",
+    "source": "knowledge/hermits/tangotek.md"
+  },
+  {
+    "id": "q006",
+    "question": "Which season is the longest in Hermitcraft history?",
+    "options": ["Season 6", "Season 7", "Season 8", "Season 9"],
+    "answer": "Season 9",
+    "difficulty": "easy",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-9.md"
+  },
+  {
+    "id": "q007",
+    "question": "Which season is the shortest vanilla season in Hermitcraft history?",
+    "options": ["Season 5", "Season 6", "Season 8", "Season 10"],
+    "answer": "Season 8",
+    "difficulty": "easy",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-8.md"
+  },
+  {
+    "id": "q008",
+    "question": "What is Grian's most famous alter ego?",
+    "options": ["The Barge Man", "Poultry Man", "Hot Guy", "The Architect"],
+    "answer": "Poultry Man",
+    "difficulty": "easy",
+    "category": "lore",
+    "source": "knowledge/lore/in-jokes-and-memes.md"
+  },
+  {
+    "id": "q009",
+    "question": "Which hermit's real-life cat inspired an official Minecraft cat skin variant?",
+    "options": ["Grian", "Xisumavoid", "GoodTimesWithScar", "PearlescentMoon"],
+    "answer": "GoodTimesWithScar",
+    "difficulty": "easy",
+    "category": "hermits",
+    "source": "knowledge/lore/in-jokes-and-memes.md"
+  },
+  {
+    "id": "q010",
+    "question": "What material is Iskall85 famously known to despise?",
+    "options": ["Sand", "Gravel", "Diorite", "Andesite"],
+    "answer": "Diorite",
+    "difficulty": "easy",
+    "category": "hermits",
+    "source": "knowledge/lore/in-jokes-and-memes.md"
+  },
+  {
+    "id": "q011",
+    "question": "Who won the Demise game in Season 6?",
+    "options": ["Grian", "Mumbo Jumbo", "Iskall85", "Xisumavoid"],
+    "answer": "Iskall85",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/demise.md"
+  },
+  {
+    "id": "q012",
+    "question": "Who won the Demise game in Season 10?",
+    "options": ["Grian", "FalseSymmetry", "Xisumavoid", "GeminiTay"],
+    "answer": "FalseSymmetry",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/demise.md"
+  },
+  {
+    "id": "q013",
+    "question": "What was the entry cost for Demise in Season 6?",
+    "options": ["10 diamonds", "25 diamonds", "50 diamonds", "100 diamonds"],
+    "answer": "50 diamonds",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/demise.md"
+  },
+  {
+    "id": "q014",
+    "question": "What armor restriction applied to Demise contestants in Season 6?",
+    "options": ["No armor at all", "No diamond armor", "No enchanted armor", "Leather armor only"],
+    "answer": "No diamond armor",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/demise.md"
+  },
+  {
+    "id": "q015",
+    "question": "Who led the Mycelium Resistance in Season 7?",
+    "options": ["TangoTek", "Xisumavoid", "Grian", "ImpulseSV"],
+    "answer": "Grian",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/mycelium-resistance-season7.md"
+  },
+  {
+    "id": "q016",
+    "question": "Who led HEP (HermitCraft Environmental Protection) in Season 7?",
+    "options": ["Xisumavoid", "GoodTimesWithScar", "TangoTek", "Mumbo Jumbo"],
+    "answer": "GoodTimesWithScar",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/mycelium-resistance-season7.md"
+  },
+  {
+    "id": "q017",
+    "question": "What was the final Mycelium Resistance vs HEP score in their minigame series?",
+    "options": ["3-6", "5-4", "6-3", "7-2"],
+    "answer": "6-3",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/mycelium-resistance-season7.md"
+  },
+  {
+    "id": "q018",
+    "question": "What was the total profit earned by the Sahara mega-shop?",
+    "options": ["64 diamond blocks", "32 diamond blocks", "10 diamond blocks", "5 diamond blocks"],
+    "answer": "5 diamond blocks",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/sahara-and-economy.md"
+  },
+  {
+    "id": "q019",
+    "question": "Who were the three members of The Architechs who built Sahara?",
+    "options": [
+      "Grian, Mumbo Jumbo, and Xisumavoid",
+      "Grian, Mumbo Jumbo, and Iskall85",
+      "Grian, TangoTek, and Iskall85",
+      "Mumbo Jumbo, TangoTek, and Iskall85"
+    ],
+    "answer": "Grian, Mumbo Jumbo, and Iskall85",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/sahara-and-economy.md"
+  },
+  {
+    "id": "q020",
+    "question": "Which faction in Season 6's civil war was led by Docm77?",
+    "options": ["G-Team", "Team S.T.A.R.", "The Resistance", "HEP"],
+    "answer": "Team S.T.A.R.",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/civil-war-season6.md"
+  },
+  {
+    "id": "q021",
+    "question": "What dramatic event ended Season 8?",
+    "options": [
+      "A server-wide TNT explosion",
+      "The moon crashed into the planet",
+      "A dragon destroyed the world",
+      "A meteor wiped out the shopping district"
+    ],
+    "answer": "The moon crashed into the planet",
+    "difficulty": "medium",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-8.md"
+  },
+  {
+    "id": "q022",
+    "question": "Which two hermits joined as new members in Season 8?",
+    "options": [
+      "Skizzleman and SmallishBeans",
+      "GeminiTay and PearlescentMoon",
+      "Skizzleman and GeminiTay",
+      "PearlescentMoon and Skizzleman"
+    ],
+    "answer": "GeminiTay and PearlescentMoon",
+    "difficulty": "medium",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-8.md"
+  },
+  {
+    "id": "q023",
+    "question": "Who joined to fix MumboJumbo's iron farm in Season 2 and never left?",
+    "options": ["EthosLab", "Iskall85", "TangoTek", "ImpulseSV"],
+    "answer": "TangoTek",
+    "difficulty": "medium",
+    "category": "hermits",
+    "source": "knowledge/hermits/tangotek.md"
+  },
+  {
+    "id": "q024",
+    "question": "Which season was Season 7's shopping district nicknamed 'Cowmercial District'?",
+    "options": ["Season 6", "Season 7", "Season 8", "Season 9"],
+    "answer": "Season 7",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/sahara-and-economy.md"
+  },
+  {
+    "id": "q025",
+    "question": "Who were the arms dealers in Season 6's civil war, selling to both sides?",
+    "options": [
+      "EthosLab and VintageBeef",
+      "GoodTimesWithScar and Cubfan135",
+      "BdoubleO100 and Keralis",
+      "ZombieCleo and JoeHills"
+    ],
+    "answer": "GoodTimesWithScar and Cubfan135",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/civil-war-season6.md"
+  },
+  {
+    "id": "q026",
+    "question": "Which season used the Fabric mod loader?",
+    "options": ["Season 7", "Season 8", "Season 9", "Season 10"],
+    "answer": "Season 9",
+    "difficulty": "medium",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-9.md"
+  },
+  {
+    "id": "q027",
+    "question": "Which two hermits joined as new members in Season 10?",
+    "options": [
+      "GeminiTay and PearlescentMoon",
+      "Skizzleman and SmallishBeans",
+      "Skizzleman and GeminiTay",
+      "SmallishBeans and PearlescentMoon"
+    ],
+    "answer": "Skizzleman and SmallishBeans",
+    "difficulty": "medium",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-10.md"
+  },
+  {
+    "id": "q028",
+    "question": "Which season was the first to have zero roster changes?",
+    "options": ["Season 6", "Season 7", "Season 8", "Season 9"],
+    "answer": "Season 7",
+    "difficulty": "medium",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-7.md"
+  },
+  {
+    "id": "q029",
+    "question": "How many seasons had TangoTek participated in through Season 11?",
+    "options": ["8", "9", "10", "11"],
+    "answer": "10",
+    "difficulty": "medium",
+    "category": "hermits",
+    "source": "knowledge/hermits/tangotek.md"
+  },
+  {
+    "id": "q030",
+    "question": "Which group did Grian, MumboJumbo, GoodTimesWithScar, ImpulseSV, and PearlescentMoon form in Season 8?",
+    "options": ["The Resistance", "The Buttercups", "Boatem", "The Soup Group"],
+    "answer": "Boatem",
+    "difficulty": "medium",
+    "category": "lore",
+    "source": "knowledge/lore/boatem-season8.md"
+  },
+  {
+    "id": "q031",
+    "question": "On what exact date was the Hermitcraft server founded?",
+    "options": ["April 1, 2012", "April 13, 2012", "June 9, 2012", "August 9, 2012"],
+    "answer": "April 13, 2012",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-1.md"
+  },
+  {
+    "id": "q032",
+    "question": "On what date did BdoubleO100 join during Season 1?",
+    "options": ["October 5, 2012", "January 5, 2013", "March 5, 2013", "June 9, 2013"],
+    "answer": "January 5, 2013",
+    "difficulty": "hard",
+    "category": "hermits",
+    "source": "knowledge/seasons/season-1.md"
+  },
+  {
+    "id": "q033",
+    "question": "What is Grian's real name?",
+    "options": ["George Bennett", "Charles Batchelor", "Oliver Brotherhood", "Jack Hughes"],
+    "answer": "Charles Batchelor",
+    "difficulty": "hard",
+    "category": "hermits",
+    "source": "knowledge/hermits/grian.md"
+  },
+  {
+    "id": "q034",
+    "question": "What is MumboJumbo's real name?",
+    "options": ["Jack Murphy", "Charles Batchelor", "Oliver Brotherhood", "Simon Clarke"],
+    "answer": "Oliver Brotherhood",
+    "difficulty": "hard",
+    "category": "hermits",
+    "source": "knowledge/hermits/mumbo-jumbo.md"
+  },
+  {
+    "id": "q035",
+    "question": "What is the Season 7 server seed?",
+    "options": ["-2143500864", "-7381235180058670651", "1409558884499", "42069420"],
+    "answer": "-2143500864",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-7.md"
+  },
+  {
+    "id": "q036",
+    "question": "What is the Season 8 server seed?",
+    "options": ["-2143500864", "-7381235180058670651", "8675309", "-42000000000"],
+    "answer": "-7381235180058670651",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-8.md"
+  },
+  {
+    "id": "q037",
+    "question": "What was the space tax rule in Season 7's shopping district?",
+    "options": [
+      "1 gold block per 64 blocks",
+      "1 diamond block per 100 blocks (10x10 area)",
+      "1 emerald block per 50 blocks",
+      "1 diamond per 25 blocks"
+    ],
+    "answer": "1 diamond block per 100 blocks (10x10 area)",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/sahara-and-economy.md"
+  },
+  {
+    "id": "q038",
+    "question": "Which Season 6 civil war faction member was MumboJumbo a double agent for?",
+    "options": [
+      "He spied for Team S.T.A.R. while on G-Team",
+      "He spied for G-Team while officially on Team S.T.A.R.",
+      "He was a neutral arms dealer",
+      "He switched factions mid-war officially"
+    ],
+    "answer": "He spied for G-Team while officially on Team S.T.A.R.",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/civil-war-season6.md"
+  },
+  {
+    "id": "q039",
+    "question": "What caused the Season 6 civil war to start?",
+    "options": [
+      "A griefing incident in the shopping district",
+      "Iskall85 built a Grian statue with diorite bird droppings",
+      "Grian stole diamonds from Docm77",
+      "A prank war that escalated out of control"
+    ],
+    "answer": "Iskall85 built a Grian statue with diorite bird droppings",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/civil-war-season6.md"
+  },
+  {
+    "id": "q040",
+    "question": "What was the prize for ZombieCleo's Head Games event in Season 7?",
+    "options": ["128 diamonds", "200 diamonds", "288 diamonds", "300 diamonds"],
+    "answer": "288 diamonds",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/sahara-and-economy.md"
+  },
+  {
+    "id": "q041",
+    "question": "What was the title of MumboJumbo's first Hermitcraft video?",
+    "options": [
+      "\"Welcome to Hermitcraft\"",
+      "\"HermitCraft: Episode 0 - Welcome Home\"",
+      "\"My First Day on Hermitcraft\"",
+      "\"HermitCraft - The Beginning\""
+    ],
+    "answer": "\"HermitCraft: Episode 0 - Welcome Home\"",
+    "difficulty": "hard",
+    "category": "hermits",
+    "source": "knowledge/hermits/mumbo-jumbo.md"
+  },
+  {
+    "id": "q042",
+    "question": "In which episode of Season 6 did Poultry Man first appear?",
+    "options": ["Episode 10", "Episode 15", "Episode 22", "Episode 30"],
+    "answer": "Episode 22",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/in-jokes-and-memes.md"
+  },
+  {
+    "id": "q043",
+    "question": "How long did TangoTek spend building Decked Out 2 in Season 9?",
+    "options": ["6 months", "8 months", "11+ months", "Over 2 years"],
+    "answer": "11+ months",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/seasons/season-9.md"
+  },
+  {
+    "id": "q044",
+    "question": "What group did Zedaph, ImpulseSV, TangoTek, and Skizzleman form in Season 10?",
+    "options": ["The Soup Group", "Boatem", "ZITS", "The Buttercups"],
+    "answer": "ZITS",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/seasons/season-10.md"
+  },
+  {
+    "id": "q045",
+    "question": "What prime factor of the Season 6 server seed did JoeHills reveal publicly?",
+    "options": ["1,234,567,891", "1,409,558,884,499", "2,147,483,647", "9,999,999,999,999"],
+    "answer": "1,409,558,884,499",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-6.md"
+  },
+  {
+    "id": "q046",
+    "question": "What prize did FalseSymmetry receive for winning Demise in Season 10?",
+    "options": [
+      "64 diamond blocks",
+      "The Wither trophy",
+      "Joker Permit to sell any item",
+      "A dedicated shop plot"
+    ],
+    "answer": "Joker Permit to sell any item",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/demise.md"
+  },
+  {
+    "id": "q047",
+    "question": "How was FalseSymmetry ceremonially eliminated at the end of Demise in Season 10?",
+    "options": [
+      "Pushed into lava by Grian",
+      "Simultaneous dispensers fired by MumboJumbo, Xisumavoid, StressMonster101, and xBCrafted",
+      "Blown up by a creeper farm",
+      "Fell into the void"
+    ],
+    "answer": "Simultaneous dispensers fired by MumboJumbo, Xisumavoid, StressMonster101, and xBCrafted",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/demise.md"
+  },
+  {
+    "id": "q048",
+    "question": "What exact date did Season 7 begin?",
+    "options": ["January 1, 2020", "February 28, 2020", "March 15, 2020", "April 5, 2020"],
+    "answer": "February 28, 2020",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-7.md"
+  },
+  {
+    "id": "q049",
+    "question": "Which strategy did the Mycelium Resistance use to spread mycelium naturally?",
+    "options": [
+      "Placing mycelium blocks at night",
+      "Using endermen to carry mycelium",
+      "Breeding sheep that walked over mycelium",
+      "Converting grass blocks with water"
+    ],
+    "answer": "Breeding sheep that walked over mycelium",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/lore/mycelium-resistance-season7.md"
+  },
+  {
+    "id": "q050",
+    "question": "How many total members were there at the end of Season 1 (full roster count)?",
+    "options": ["10", "15", "22", "29"],
+    "answer": "29",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-1.md"
+  },
+  {
+    "id": "q051",
+    "question": "Who co-founded Wynncraft, the largest MMORPG built in Minecraft?",
+    "options": ["Mumbo Jumbo", "Xisumavoid", "Grian", "TangoTek"],
+    "answer": "Grian",
+    "difficulty": "hard",
+    "category": "hermits",
+    "source": "knowledge/hermits/grian.md"
+  },
+  {
+    "id": "q052",
+    "question": "What group formed by GoodTimesWithScar, Grian, Cubfan135, and Skizzleman in Season 10?",
+    "options": ["ZITS", "The Soup Group", "Poe-Poe", "The Buttercups"],
+    "answer": "Poe-Poe",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/seasons/season-10.md"
+  },
+  {
+    "id": "q053",
+    "question": "What is ImpulseSV's birth date?",
+    "options": ["March 9, 1979", "March 9, 1981", "August 9, 1993", "October 15, 1985"],
+    "answer": "March 9, 1981",
+    "difficulty": "hard",
+    "category": "hermits",
+    "source": "knowledge/hermits/impulsesv.md"
+  },
+  {
+    "id": "q054",
+    "question": "What was the name of the group formed by ImpulseSV, PearlescentMoon, and GeminiTay in Season 9?",
+    "options": ["Boatem", "The Soup Group", "ZITS", "Team JOLTS"],
+    "answer": "The Soup Group",
+    "difficulty": "hard",
+    "category": "lore",
+    "source": "knowledge/seasons/season-9.md"
+  },
+  {
+    "id": "q055",
+    "question": "What Minecraft version was Season 8 built on?",
+    "options": ["1.16.x", "1.17 (Caves & Cliffs Part 1)", "1.18.1", "1.19.x"],
+    "answer": "1.17 (Caves & Cliffs Part 1)",
+    "difficulty": "hard",
+    "category": "seasons",
+    "source": "knowledge/seasons/season-8.md"
+  }
+]

--- a/tests/test_trivia.py
+++ b/tests/test_trivia.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Tests for tools/trivia.py"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Make sure we can import the module under test
+sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
+import trivia  # noqa: E402
+
+
+QUESTIONS_FILE = Path(__file__).parent.parent / "knowledge" / "trivia" / "questions.json"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run_cli(*args: str) -> tuple[str, int]:
+    """Run main() with the given args, capture stdout, return (output, code)."""
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        code = trivia.main(list(args))
+    return buf.getvalue(), code
+
+
+# ---------------------------------------------------------------------------
+# Questions file
+# ---------------------------------------------------------------------------
+
+class TestQuestionsFile(unittest.TestCase):
+    def test_file_exists(self):
+        self.assertTrue(QUESTIONS_FILE.exists(), "questions.json not found")
+
+    def test_is_valid_json(self):
+        with QUESTIONS_FILE.open() as fh:
+            data = json.load(fh)
+        self.assertIsInstance(data, list)
+
+    def test_at_least_50_questions(self):
+        with QUESTIONS_FILE.open() as fh:
+            data = json.load(fh)
+        self.assertGreaterEqual(len(data), 50, "Need at least 50 questions")
+
+    def test_all_questions_valid(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        errors: list[str] = []
+        for q in questions:
+            qid = q.get("id", "?")
+            for err in trivia.validate_question(q):
+                errors.append(f"{qid}: {err}")
+        self.assertEqual(errors, [], f"Validation errors:\n" + "\n".join(errors))
+
+    def test_unique_ids(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        ids = [q.get("id") for q in questions]
+        self.assertEqual(len(ids), len(set(ids)), "Duplicate question IDs found")
+
+    def test_all_difficulties_present(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        diffs = {q.get("difficulty") for q in questions}
+        self.assertIn("easy", diffs)
+        self.assertIn("medium", diffs)
+        self.assertIn("hard", diffs)
+
+    def test_all_categories_present(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        cats = {q.get("category") for q in questions}
+        self.assertIn("seasons", cats)
+        self.assertIn("hermits", cats)
+        self.assertIn("lore", cats)
+
+    def test_every_answer_in_options(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        for q in questions:
+            self.assertIn(
+                q["answer"],
+                q["options"],
+                f"Question {q['id']}: answer '{q['answer']}' not in options",
+            )
+
+    def test_exactly_4_options_per_question(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        for q in questions:
+            self.assertEqual(
+                len(q["options"]),
+                4,
+                f"Question {q['id']}: expected 4 options, got {len(q['options'])}",
+            )
+
+    def test_source_field_populated(self):
+        with QUESTIONS_FILE.open() as fh:
+            questions = json.load(fh)
+        for q in questions:
+            self.assertTrue(
+                q.get("source"), f"Question {q['id']}: empty source field"
+            )
+
+
+# ---------------------------------------------------------------------------
+# filter_questions
+# ---------------------------------------------------------------------------
+
+class TestFilterQuestions(unittest.TestCase):
+    def setUp(self):
+        self.questions = trivia.load_questions()
+
+    def test_no_filter_returns_all(self):
+        result = trivia.filter_questions(self.questions)
+        self.assertEqual(len(result), len(self.questions))
+
+    def test_filter_easy(self):
+        result = trivia.filter_questions(self.questions, difficulty="easy")
+        self.assertTrue(all(q["difficulty"] == "easy" for q in result))
+        self.assertGreater(len(result), 0)
+
+    def test_filter_medium(self):
+        result = trivia.filter_questions(self.questions, difficulty="medium")
+        self.assertTrue(all(q["difficulty"] == "medium" for q in result))
+        self.assertGreater(len(result), 0)
+
+    def test_filter_hard(self):
+        result = trivia.filter_questions(self.questions, difficulty="hard")
+        self.assertTrue(all(q["difficulty"] == "hard" for q in result))
+        self.assertGreater(len(result), 0)
+
+    def test_filter_seasons(self):
+        result = trivia.filter_questions(self.questions, category="seasons")
+        self.assertTrue(all(q["category"] == "seasons" for q in result))
+        self.assertGreater(len(result), 0)
+
+    def test_filter_hermits(self):
+        result = trivia.filter_questions(self.questions, category="hermits")
+        self.assertTrue(all(q["category"] == "hermits" for q in result))
+        self.assertGreater(len(result), 0)
+
+    def test_filter_lore(self):
+        result = trivia.filter_questions(self.questions, category="lore")
+        self.assertTrue(all(q["category"] == "lore" for q in result))
+        self.assertGreater(len(result), 0)
+
+    def test_combined_filter(self):
+        result = trivia.filter_questions(
+            self.questions, difficulty="hard", category="seasons"
+        )
+        for q in result:
+            self.assertEqual(q["difficulty"], "hard")
+            self.assertEqual(q["category"], "seasons")
+
+
+# ---------------------------------------------------------------------------
+# validate_question
+# ---------------------------------------------------------------------------
+
+class TestValidateQuestion(unittest.TestCase):
+    def _good(self):
+        return {
+            "id": "q001",
+            "question": "Who?",
+            "options": ["A", "B", "C", "D"],
+            "answer": "A",
+            "difficulty": "easy",
+            "category": "seasons",
+            "source": "knowledge/seasons/season-1.md",
+        }
+
+    def test_valid_question_no_errors(self):
+        self.assertEqual(trivia.validate_question(self._good()), [])
+
+    def test_missing_field(self):
+        q = self._good()
+        del q["answer"]
+        errors = trivia.validate_question(q)
+        self.assertTrue(any("answer" in e for e in errors))
+
+    def test_answer_not_in_options(self):
+        q = self._good()
+        q["answer"] = "Z"
+        errors = trivia.validate_question(q)
+        self.assertTrue(any("not found in options" in e for e in errors))
+
+    def test_invalid_difficulty(self):
+        q = self._good()
+        q["difficulty"] = "impossible"
+        errors = trivia.validate_question(q)
+        self.assertTrue(any("difficulty" in e for e in errors))
+
+    def test_invalid_category(self):
+        q = self._good()
+        q["category"] = "minecraft"
+        errors = trivia.validate_question(q)
+        self.assertTrue(any("category" in e for e in errors))
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+class TestCLI(unittest.TestCase):
+    def test_default_returns_one_question_json(self):
+        out, code = run_cli("--seed", "42")
+        self.assertEqual(code, 0)
+        obj = json.loads(out)
+        self.assertIn("question", obj)
+        self.assertIn("answer", obj)
+        self.assertIn("options", obj)
+
+    def test_count_returns_list(self):
+        out, code = run_cli("--count", "3", "--seed", "42")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 3)
+
+    def test_count_1_returns_object_not_list(self):
+        out, code = run_cli("--count", "1", "--seed", "0")
+        self.assertEqual(code, 0)
+        data = json.loads(out)
+        self.assertIsInstance(data, dict)
+
+    def test_difficulty_filter(self):
+        out, code = run_cli("--difficulty", "easy", "--all")
+        self.assertEqual(code, 0)
+        questions = json.loads(out)
+        self.assertTrue(all(q["difficulty"] == "easy" for q in questions))
+
+    def test_category_filter(self):
+        out, code = run_cli("--category", "lore", "--all")
+        self.assertEqual(code, 0)
+        questions = json.loads(out)
+        self.assertTrue(all(q["category"] == "lore" for q in questions))
+
+    def test_all_flag(self):
+        out, code = run_cli("--all")
+        self.assertEqual(code, 0)
+        questions = json.loads(out)
+        self.assertIsInstance(questions, list)
+        self.assertGreaterEqual(len(questions), 50)
+
+    def test_stats_flag(self):
+        out, code = run_cli("--stats")
+        self.assertEqual(code, 0)
+        stats = json.loads(out)
+        self.assertIn("total_questions", stats)
+        self.assertIn("by_difficulty", stats)
+        self.assertIn("by_category", stats)
+        self.assertGreaterEqual(stats["total_questions"], 50)
+
+    def test_no_match_returns_exit_1(self):
+        # Ask for questions that don't exist through patching the loader
+        original_load = trivia.load_questions
+        trivia.load_questions = lambda path=None: []
+        try:
+            import io
+            from contextlib import redirect_stdout, redirect_stderr
+            buf_out = io.StringIO()
+            buf_err = io.StringIO()
+            with redirect_stdout(buf_out), redirect_stderr(buf_err):
+                code = trivia.main(["--difficulty", "easy"])
+            self.assertEqual(code, 1)
+        finally:
+            trivia.load_questions = original_load
+
+    def test_seed_produces_reproducible_output(self):
+        out1, _ = run_cli("--seed", "1337", "--count", "3")
+        out2, _ = run_cli("--seed", "1337", "--count", "3")
+        self.assertEqual(out1, out2)
+
+    def test_different_seeds_likely_differ(self):
+        out1, _ = run_cli("--seed", "1", "--count", "5")
+        out2, _ = run_cli("--seed", "999", "--count", "5")
+        # With 55 questions and picking 5, different seeds very likely differ
+        # (this can theoretically fail but is astronomically unlikely)
+        q1 = [q["id"] for q in json.loads(out1)]
+        q2 = [q["id"] for q in json.loads(out2)]
+        self.assertNotEqual(q1, q2)
+
+
+# ---------------------------------------------------------------------------
+# Specific content sanity checks
+# ---------------------------------------------------------------------------
+
+class TestContentSanity(unittest.TestCase):
+    """Spot-check that key Hermitcraft facts are correct in the question bank."""
+
+    def setUp(self):
+        with QUESTIONS_FILE.open() as fh:
+            self.questions = json.load(fh)
+        self.by_id = {q["id"]: q for q in self.questions}
+
+    def test_hermitcraft_founded_by_generikb(self):
+        q = self.by_id["q001"]
+        self.assertEqual(q["answer"], "Generikb")
+
+    def test_server_founded_2012(self):
+        q = self.by_id["q002"]
+        self.assertEqual(q["answer"], "2012")
+
+    def test_xisuma_became_admin(self):
+        q = self.by_id["q003"]
+        self.assertEqual(q["answer"], "Xisumavoid")
+
+    def test_grian_joined_season_6(self):
+        q = self.by_id["q004"]
+        self.assertEqual(q["answer"], "Grian")
+
+    def test_decked_out_is_tangoteks(self):
+        q = self.by_id["q005"]
+        self.assertEqual(q["answer"], "Decked Out")
+
+    def test_season_9_longest(self):
+        q = self.by_id["q006"]
+        self.assertEqual(q["answer"], "Season 9")
+
+    def test_season_8_shortest(self):
+        q = self.by_id["q007"]
+        self.assertEqual(q["answer"], "Season 8")
+
+    def test_iskall85_won_demise_season6(self):
+        q = self.by_id["q011"]
+        self.assertEqual(q["answer"], "Iskall85")
+
+    def test_false_symmetry_won_demise_season10(self):
+        q = self.by_id["q012"]
+        self.assertEqual(q["answer"], "FalseSymmetry")
+
+    def test_mycelium_resistance_won_6_3(self):
+        q = self.by_id["q017"]
+        self.assertEqual(q["answer"], "6-3")
+
+    def test_sahara_profit_5_diamond_blocks(self):
+        q = self.by_id["q018"]
+        self.assertEqual(q["answer"], "5 diamond blocks")
+
+    def test_grian_real_name(self):
+        q = self.by_id["q033"]
+        self.assertEqual(q["answer"], "Charles Batchelor")
+
+    def test_mumbo_real_name(self):
+        q = self.by_id["q034"]
+        self.assertEqual(q["answer"], "Oliver Brotherhood")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/trivia.py
+++ b/tools/trivia.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Hermitcraft Trivia Quiz CLI
+============================
+Serves trivia questions drawn from the knowledge base.
+
+Usage
+-----
+  python3 tools/trivia.py                         # one random question
+  python3 tools/trivia.py --count 5               # 5 random questions
+  python3 tools/trivia.py --difficulty easy        # filter by difficulty
+  python3 tools/trivia.py --category seasons       # filter by category
+  python3 tools/trivia.py --difficulty hard --count 3
+  python3 tools/trivia.py --all                    # all questions
+  python3 tools/trivia.py --stats                  # summary stats only
+
+Output is always newline-delimited JSON (one object per line), or a single
+JSON array when --all is used, so it's easy to pipe into jq.
+
+Exit codes
+----------
+  0  success
+  1  no questions match the given filters
+  2  bad arguments or questions file not found
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+
+QUESTIONS_FILE = Path(__file__).parent.parent / "knowledge" / "trivia" / "questions.json"
+
+VALID_DIFFICULTIES = {"easy", "medium", "hard"}
+VALID_CATEGORIES = {"seasons", "hermits", "lore"}
+
+
+def load_questions(path: Path = QUESTIONS_FILE) -> list[dict]:
+    """Load and validate the questions JSON file."""
+    if not path.exists():
+        sys.stderr.write(f"[trivia] questions file not found: {path}\n")
+        sys.exit(2)
+    try:
+        with path.open() as fh:
+            questions = json.load(fh)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[trivia] malformed JSON in {path}: {exc}\n")
+        sys.exit(2)
+    if not isinstance(questions, list):
+        sys.stderr.write(f"[trivia] questions file must be a JSON array\n")
+        sys.exit(2)
+    return questions
+
+
+def filter_questions(
+    questions: list[dict],
+    difficulty: str | None = None,
+    category: str | None = None,
+) -> list[dict]:
+    """Return questions matching the given filters (None = no filter)."""
+    result = questions
+    if difficulty:
+        result = [q for q in result if q.get("difficulty") == difficulty]
+    if category:
+        result = [q for q in result if q.get("category") == category]
+    return result
+
+
+def validate_question(q: dict) -> list[str]:
+    """Return a list of validation errors for a single question dict."""
+    errors: list[str] = []
+    required = ("id", "question", "options", "answer", "difficulty", "category", "source")
+    for field in required:
+        if field not in q:
+            errors.append(f"missing field '{field}'")
+    if "options" in q and not isinstance(q["options"], list):
+        errors.append("'options' must be an array")
+    if "options" in q and "answer" in q and q["answer"] not in q["options"]:
+        errors.append(
+            f"answer '{q['answer']}' not found in options {q['options']}"
+        )
+    if "difficulty" in q and q["difficulty"] not in VALID_DIFFICULTIES:
+        errors.append(f"difficulty must be one of {sorted(VALID_DIFFICULTIES)}")
+    if "category" in q and q["category"] not in VALID_CATEGORIES:
+        errors.append(f"category must be one of {sorted(VALID_CATEGORIES)}")
+    return errors
+
+
+def print_stats(questions: list[dict]) -> None:
+    """Print a human-readable summary to stdout."""
+    total = len(questions)
+    by_diff: dict[str, int] = {}
+    by_cat: dict[str, int] = {}
+    for q in questions:
+        d = q.get("difficulty", "unknown")
+        c = q.get("category", "unknown")
+        by_diff[d] = by_diff.get(d, 0) + 1
+        by_cat[c] = by_cat.get(c, 0) + 1
+    stats = {
+        "total_questions": total,
+        "by_difficulty": by_diff,
+        "by_category": by_cat,
+    }
+    print(json.dumps(stats, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Hermitcraft Trivia Quiz CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--difficulty",
+        choices=sorted(VALID_DIFFICULTIES),
+        help="Filter by difficulty level",
+    )
+    parser.add_argument(
+        "--category",
+        choices=sorted(VALID_CATEGORIES),
+        help="Filter by category",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        metavar="N",
+        help="Number of questions to return (default: 1)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_questions",
+        help="Return all matching questions as a JSON array",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Print question bank stats and exit",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Random seed (for reproducible output in tests)",
+    )
+
+    args = parser.parse_args(argv)
+
+    questions = load_questions()
+
+    if args.stats:
+        print_stats(questions)
+        return 0
+
+    filtered = filter_questions(questions, args.difficulty, args.category)
+
+    if not filtered:
+        sys.stderr.write(
+            f"[trivia] no questions match filters "
+            f"(difficulty={args.difficulty!r}, category={args.category!r})\n"
+        )
+        return 1
+
+    if args.all_questions:
+        print(json.dumps(filtered, indent=2))
+        return 0
+
+    rng = random.Random(args.seed)
+    count = min(args.count, len(filtered))
+    selected = rng.sample(filtered, count)
+
+    if count == 1:
+        print(json.dumps(selected[0], indent=2))
+    else:
+        print(json.dumps(selected, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #34

## Summary

Turns the static knowledge base into an interactive product by adding a trivia quiz CLI. Users can now query questions by difficulty, category, or get a random question — all backed by the knowledge files already in this repo.

- **`knowledge/trivia/questions.json`** — 55 questions drawn directly from the knowledge base, spread across 3 difficulties and 3 categories:
  | | easy | medium | hard |
  |---|---|---|---|
  | seasons | ✓ | ✓ | ✓ |
  | hermits | ✓ | ✓ | ✓ |
  | lore | ✓ | ✓ | ✓ |

  Every question has: `id`, `question`, 4 `options`, `answer`, `difficulty`, `category`, `source` (pointing back to the knowledge file).

- **`tools/trivia.py`** — CLI tool with filtering, random sampling, and JSON output:
  ```
  python3 tools/trivia.py                          # 1 random question (JSON)
  python3 tools/trivia.py --count 5                # 5 random questions
  python3 tools/trivia.py --difficulty hard        # hard questions only
  python3 tools/trivia.py --category lore          # lore category only
  python3 tools/trivia.py --difficulty hard --category seasons --count 3
  python3 tools/trivia.py --all                    # full bank as JSON array
  python3 tools/trivia.py --stats                  # summary stats
  python3 tools/trivia.py --seed 42                # reproducible output
  ```

- **`tests/test_trivia.py`** — 46 tests across 5 test classes:
  - `TestQuestionsFile` — structural validation (≥50 questions, unique IDs, 4 options per question, answer always in options, all 3 difficulties and categories present, source field populated)
  - `TestFilterQuestions` — all filter combinations
  - `TestValidateQuestion` — schema validation errors
  - `TestCLI` — end-to-end CLI behaviour (count, filters, `--all`, `--stats`, `--seed` reproducibility, exit code 1 on no match)
  - `TestContentSanity` — 13 spot-checks of canonical Hermitcraft facts (who founded the server, who won Demise, Sahara's final profit, real names, etc.)

## Test plan
- [ ] `python3 tests/test_trivia.py` → 46 passed, 0 failed
- [ ] `python3 tools/trivia.py --stats` → JSON with `total_questions >= 50`
- [ ] `python3 tools/trivia.py --difficulty easy --seed 1` → valid question object
- [ ] `python3 tools/trivia.py --difficulty hard --category seasons --count 3` → 3 hard season questions
- [ ] `python3 tools/trivia.py --all | python3 -c "import sys,json; qs=json.load(sys.stdin); print(len(qs))"` → 55