### PR TITLE
[hermitcraft-agent] Add hermit anniversary lookup to On This Day digest

### DIFF
--- a/knowledge/hermits/bdoubleo100.md
+++ b/knowledge/hermits/bdoubleo100.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/bdoubleo
 hermitcraft_page: https://hermitcraft.com/bdoubleo100
 joined_season: 1
 joined_year: 2013
+join_date: "2013-01-05"
+yt_channel_start: "2011"
 status: active
 nationality: American
 specialties:

--- a/knowledge/hermits/docm77.md
+++ b/knowledge/hermits/docm77.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/docm77
 hermitcraft_page: https://hermitcraft.com/docm77
 joined_season: 3
 joined_year: 2015
+join_date: "2014-10"
+yt_channel_start: "2012"
 status: active
 nationality: Unknown (European)
 specialties:

--- a/knowledge/hermits/ethoslab.md
+++ b/knowledge/hermits/ethoslab.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/EthosLab
 hermitcraft_page: https://hermitcraft.com/ethoslab
 joined_season: 3
 joined_year: 2015
+join_date: "2015-03"
+yt_channel_start: "2010"
 status: active
 nationality: Canadian
 specialties:

--- a/knowledge/hermits/falsesymmetry.md
+++ b/knowledge/hermits/falsesymmetry.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/FalseSymmetry
 hermitcraft_page: https://hermitcraft.com/falsesymmetry
 joined_season: 2
 joined_year: 2014
+join_date: "2014"
 status: active
 nationality: Unknown
 specialties:

--- a/knowledge/hermits/goodtimeswithscar.md
+++ b/knowledge/hermits/goodtimeswithscar.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/c/GoodTimesWithScar
 hermitcraft_page: https://hermitcraft.com/goodtimeswithscar
 joined_season: 4
 joined_year: 2016
+join_date: "2016-03"
+yt_channel_start: "2014"
 status: active
 nationality: American
 specialties:

--- a/knowledge/hermits/grian.md
+++ b/knowledge/hermits/grian.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/Xelqua
 hermitcraft_page: https://hermitcraft.com/grian
 joined_season: 6
 joined_year: 2018
+join_date: "2018-07-19"
+yt_channel_start: "2012"
 status: active
 nationality: British
 specialties:

--- a/knowledge/hermits/hypnotizd.md
+++ b/knowledge/hermits/hypnotizd.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/hypnotizd
 hermitcraft_page: https://hermitcraft.com/hypnotizd
 joined_season: 1
 joined_year: 2012
+join_date: "2012-04-13"
+yt_channel_start: "2012"
 status: active
 nationality: Unknown
 specialties:

--- a/knowledge/hermits/ijevin.md
+++ b/knowledge/hermits/ijevin.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/iJevin
 hermitcraft_page: https://hermitcraft.com/ijevin
 joined_season: 2
 joined_year: 2013
+join_date: "2013"
 status: active
 nationality: Unknown
 specialties:

--- a/knowledge/hermits/impulsesv.md
+++ b/knowledge/hermits/impulsesv.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/impulseSV
 hermitcraft_page: https://hermitcraft.com/impulsesv
 joined_season: 3
 joined_year: 2015
+join_date: "2014-10"
+yt_channel_start: "2013"
 status: active
 nationality: American
 specialties:

--- a/knowledge/hermits/iskall85.md
+++ b/knowledge/hermits/iskall85.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/iskall85
 hermitcraft_page: https://hermitcraft.com/iskall85
 joined_season: 4
 joined_year: 2016
+join_date: "2016-03"
+yt_channel_start: "2013"
 status: active
 nationality: Swedish
 specialties:

--- a/knowledge/hermits/keralis.md
+++ b/knowledge/hermits/keralis.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/Keralis
 hermitcraft_page: https://hermitcraft.com/worldofkeralis
 joined_season: 1
 joined_year: 2012
+join_date: "2012-04-13"
+yt_channel_start: "2012"
 status: active
 nationality: Swedish
 specialties:

--- a/knowledge/hermits/mumbo-jumbo.md
+++ b/knowledge/hermits/mumbo-jumbo.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/ThatMumboJumbo
 hermitcraft_page: https://hermitcraft.com/mumbojumbo
 joined_season: 2
 joined_year: 2013
+join_date: "2013"
+yt_channel_start: "2012"
 status: active
 nationality: British
 specialties:

--- a/knowledge/hermits/pearlescentmoon.md
+++ b/knowledge/hermits/pearlescentmoon.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/PearlescentMoon
 hermitcraft_page: https://hermitcraft.com/pearlescentmoon
 joined_season: 8
 joined_year: 2021
+join_date: "2021"
 status: active
 nationality: Unknown (Australian)
 specialties:

--- a/knowledge/hermits/stressmonster101.md
+++ b/knowledge/hermits/stressmonster101.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/StressMonster101
 hermitcraft_page: https://hermitcraft.com/stressmonster101
 joined_season: 5
 joined_year: 2017
+join_date: "2017-04"
 status: active
 nationality: Unknown (British)
 specialties:

--- a/knowledge/hermits/tangotek.md
+++ b/knowledge/hermits/tangotek.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/TangoTekLP
 hermitcraft_page: https://hermitcraft.com/tangoteklp
 joined_season: 2
 joined_year: 2014
+join_date: "2014"
+yt_channel_start: "2011"
 status: active
 nationality: American
 specialties:

--- a/knowledge/hermits/vintagebeef.md
+++ b/knowledge/hermits/vintagebeef.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/VintageBeef
 hermitcraft_page: https://hermitcraft.com/vintagebeef
 joined_season: 4
 joined_year: 2016
+join_date: "2016"
+yt_channel_start: "2012"
 status: active
 nationality: Canadian
 specialties:

--- a/knowledge/hermits/xbcrafted.md
+++ b/knowledge/hermits/xbcrafted.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/xBCrafted
 hermitcraft_page: https://hermitcraft.com/xbcrafted
 joined_season: 2
 joined_year: 2013
+join_date: "2013"
 status: active
 nationality: Unknown (Canadian)
 specialties:

--- a/knowledge/hermits/xisumavoid.md
+++ b/knowledge/hermits/xisumavoid.md
@@ -5,6 +5,8 @@ youtube: https://www.youtube.com/user/xisumavoid
 hermitcraft_page: https://hermitcraft.com/xisumavoid
 joined_season: 1
 joined_year: 2012
+join_date: "2012-04-13"
+yt_channel_start: "2011"
 status: active
 role: server_admin
 nationality: British

--- a/knowledge/hermits/zedaph.md
+++ b/knowledge/hermits/zedaph.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/ZedaphPlays
 hermitcraft_page: https://hermitcraft.com/zedaphplays
 joined_season: 5
 joined_year: 2017
+join_date: "2017-04"
 status: active
 nationality: Unknown
 specialties:

--- a/knowledge/hermits/zombiecleo.md
+++ b/knowledge/hermits/zombiecleo.md
@@ -5,6 +5,7 @@ youtube: https://www.youtube.com/c/ZombieCleo
 hermitcraft_page: https://hermitcraft.com/zombiecleo
 joined_season: 2
 joined_year: 2014
+join_date: "2014"
 status: active
 nationality: Unknown (British)
 pronouns: they/them

--- a/tests/test_on_this_day.py
+++ b/tests/test_on_this_day.py
@@ -2,6 +2,7 @@
 """Tests for tools/on_this_day.py"""
 
 import json
+import re
 import subprocess
 import sys
 import unittest
@@ -14,9 +15,13 @@ sys.path.insert(0, str(ROOT))
 
 from tools.on_this_day import (
     DEFAULT_WINDOW,
+    _infer_precision,
+    _parse_frontmatter,
     find_on_this_day,
     load_events,
+    load_hermit_profiles,
     matches_on_this_day,
+    synthesise_hermit_events,
     _circular_distance,
     _day_of_year,
     _parse_event_date,
@@ -361,6 +366,212 @@ class TestCLI(unittest.TestCase):
         r = self._run([])
         # Exit 0 (found events) or 1 (none today) — not 2 (error)
         self.assertIn(r.returncode, (0, 1))
+
+    def test_include_hermit_anniversaries_flag_no_crash(self):
+        r = self._run(["--month", "4", "--day", "13", "--include-hermit-anniversaries"])
+        # exit 0 (found) or 1 (none) — never 2 (error)
+        self.assertIn(r.returncode, (0, 1))
+
+    def test_include_hermit_anniversaries_surfaces_founding_join(self):
+        # April 13 is Xisumavoid's / Keralis's / Hypnotizd's join date
+        r = self._run([
+            "--month", "4", "--day", "13",
+            "--window", "0",
+            "--include-hermit-anniversaries",
+        ])
+        self.assertEqual(r.returncode, 0)
+        events = [json.loads(line) for line in r.stdout.strip().splitlines()]
+        ids = [e["id"] for e in events]
+        # At least one hermit join event for April 13 founding members
+        hermit_join_ids = [i for i in ids if i.startswith("hermit-") and i.endswith("-join")]
+        self.assertGreater(len(hermit_join_ids), 0, "Expected hermit join events on April 13")
+
+    def test_hermit_anniversary_source_field(self):
+        r = self._run([
+            "--month", "4", "--day", "13",
+            "--window", "0",
+            "--include-hermit-anniversaries",
+        ])
+        self.assertEqual(r.returncode, 0)
+        events = [json.loads(line) for line in r.stdout.strip().splitlines()]
+        hermit_events = [e for e in events if e.get("id", "").startswith("hermit-")]
+        for e in hermit_events:
+            self.assertEqual(e["source"], "hermit_profile")
+            self.assertEqual(e["type"], "milestone")
+
+    def test_anniversaries_absent_without_flag(self):
+        r = self._run(["--month", "4", "--day", "13", "--window", "0"])
+        self.assertEqual(r.returncode, 0)
+        events = [json.loads(line) for line in r.stdout.strip().splitlines()]
+        ids = [e["id"] for e in events]
+        self.assertFalse(any(i.startswith("hermit-") for i in ids))
+
+
+# ---------------------------------------------------------------------------
+# TestParseFrontmatter
+# ---------------------------------------------------------------------------
+
+class TestParseFrontmatter(unittest.TestCase):
+
+    def test_parses_scalar_fields(self):
+        content = "---\nname: Grian\njoined_season: 6\n---\n# Body"
+        fm = _parse_frontmatter(content)
+        self.assertEqual(fm["name"], "Grian")
+        self.assertEqual(fm["joined_season"], "6")
+
+    def test_strips_quotes(self):
+        content = '---\njoin_date: "2018-07-19"\nyt_channel_start: "2012"\n---\n'
+        fm = _parse_frontmatter(content)
+        self.assertEqual(fm["join_date"], "2018-07-19")
+        self.assertEqual(fm["yt_channel_start"], "2012")
+
+    def test_missing_frontmatter_returns_empty(self):
+        self.assertEqual(_parse_frontmatter("# No frontmatter"), {})
+
+    def test_unclosed_frontmatter_returns_empty(self):
+        self.assertEqual(_parse_frontmatter("---\nname: Grian\n"), {})
+
+    def test_skips_list_items(self):
+        content = "---\nname: Grian\nspecialties:\n  - building\n---\n"
+        fm = _parse_frontmatter(content)
+        self.assertIn("name", fm)
+        self.assertNotIn("specialties", fm)
+
+
+# ---------------------------------------------------------------------------
+# TestInferPrecision
+# ---------------------------------------------------------------------------
+
+class TestInferPrecision(unittest.TestCase):
+
+    def test_full_date_is_day(self):
+        self.assertEqual(_infer_precision("2012-04-13"), "day")
+
+    def test_year_month_is_month(self):
+        self.assertEqual(_infer_precision("2016-03"), "month")
+
+    def test_year_only_is_year(self):
+        self.assertEqual(_infer_precision("2013"), "year")
+
+
+# ---------------------------------------------------------------------------
+# TestSynthesiseHermitEvents
+# ---------------------------------------------------------------------------
+
+class TestSynthesiseHermitEvents(unittest.TestCase):
+
+    def _profile(self, **kwargs) -> dict:
+        base = {"name": "TestHermit", "joined_season": "7"}
+        base.update(kwargs)
+        return base
+
+    def test_join_date_creates_join_event(self):
+        profiles = [self._profile(join_date="2020-06-17")]
+        events = synthesise_hermit_events(profiles)
+        join_events = [e for e in events if e["id"].endswith("-join")]
+        self.assertEqual(len(join_events), 1)
+        e = join_events[0]
+        self.assertEqual(e["date"], "2020-06-17")
+        self.assertEqual(e["date_precision"], "day")
+        self.assertEqual(e["source"], "hermit_profile")
+        self.assertEqual(e["type"], "milestone")
+        self.assertIn("TestHermit", e["hermits"])
+
+    def test_yt_channel_start_creates_yt_event(self):
+        profiles = [self._profile(join_date="2020-06-17", yt_channel_start="2018")]
+        events = synthesise_hermit_events(profiles)
+        yt_events = [e for e in events if e["id"].endswith("-yt")]
+        self.assertEqual(len(yt_events), 1)
+        e = yt_events[0]
+        self.assertEqual(e["date"], "2018")
+        self.assertEqual(e["date_precision"], "year")
+        self.assertEqual(e["season"], 0)
+
+    def test_no_join_date_no_join_event(self):
+        profiles = [self._profile()]
+        events = synthesise_hermit_events(profiles)
+        self.assertFalse(any(e["id"].endswith("-join") for e in events))
+
+    def test_no_yt_channel_start_no_yt_event(self):
+        profiles = [self._profile(join_date="2020-06-17")]
+        events = synthesise_hermit_events(profiles)
+        self.assertFalse(any(e["id"].endswith("-yt") for e in events))
+
+    def test_month_precision_join_date(self):
+        profiles = [self._profile(join_date="2016-03")]
+        events = synthesise_hermit_events(profiles)
+        join_event = next(e for e in events if e["id"].endswith("-join"))
+        self.assertEqual(join_event["date_precision"], "month")
+
+    def test_multiple_profiles(self):
+        profiles = [
+            self._profile(name="Alpha", join_date="2012-04-13"),
+            self._profile(name="Beta",  join_date="2018-07-19"),
+        ]
+        events = synthesise_hermit_events(profiles)
+        ids = [e["id"] for e in events]
+        self.assertIn("hermit-alpha-join", ids)
+        self.assertIn("hermit-beta-join", ids)
+
+    def test_season_field_set_from_joined_season(self):
+        profiles = [self._profile(join_date="2016-03", joined_season="4")]
+        events = synthesise_hermit_events(profiles)
+        join_event = next(e for e in events if e["id"].endswith("-join"))
+        self.assertEqual(join_event["season"], 4)
+
+    def test_empty_profiles_returns_empty_list(self):
+        self.assertEqual(synthesise_hermit_events([]), [])
+
+
+# ---------------------------------------------------------------------------
+# TestHermitProfilesRealData
+# ---------------------------------------------------------------------------
+
+class TestHermitProfilesRealData(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.profiles = load_hermit_profiles()
+
+    def test_profiles_loaded(self):
+        self.assertGreater(len(self.profiles), 0)
+
+    def test_at_least_10_profiles_have_join_date(self):
+        with_join = [p for p in self.profiles if p.get("join_date")]
+        self.assertGreaterEqual(
+            len(with_join), 10,
+            f"Expected ≥10 profiles with join_date, found {len(with_join)}",
+        )
+
+    def test_join_date_format_is_valid(self):
+        """join_date values should be YYYY, YYYY-MM, or YYYY-MM-DD."""
+        pattern = re.compile(r"^\d{4}(-\d{2}(-\d{2})?)?$")
+        for p in self.profiles:
+            jd = p.get("join_date", "")
+            if jd:
+                self.assertRegex(jd, pattern, f"Bad join_date in profile {p.get('name')}")
+
+    def test_synthesised_events_are_matchable(self):
+        """Synthesised events for April 13 founding members should match."""
+        events = synthesise_hermit_events(self.profiles)
+        # Xisumavoid, Keralis, Hypnotizd all have join_date 2012-04-13
+        apr13_joins = [
+            e for e in events
+            if e.get("id", "").endswith("-join") and e.get("date") == "2012-04-13"
+        ]
+        self.assertGreaterEqual(len(apr13_joins), 3,
+            "Expected ≥3 join events for the April 13 founding date")
+
+    def test_xisumavoid_join_event_exists(self):
+        events = synthesise_hermit_events(self.profiles)
+        ids = [e["id"] for e in events]
+        self.assertIn("hermit-xisumavoid-join", ids)
+
+    def test_grian_join_event_has_correct_date(self):
+        events = synthesise_hermit_events(self.profiles)
+        grian_join = next((e for e in events if e["id"] == "hermit-grian-join"), None)
+        self.assertIsNotNone(grian_join)
+        self.assertEqual(grian_join["date"], "2018-07-19")
 
 
 if __name__ == "__main__":

--- a/tools/on_this_day.py
+++ b/tools/on_this_day.py
@@ -11,9 +11,10 @@ Usage
   python3 tools/on_this_day.py --month 4 --day 13       # April 13 (server founding!)
   python3 tools/on_this_day.py --month 6 --day 17       # June 17 (Season 7 launch)
   python3 tools/on_this_day.py --window 3               # ±3 day window (default 7)
-  python3 tools/on_this_day.py --no-approximate         # exclude approximate-precision events
-  python3 tools/on_this_day.py --include-year           # include year-only events
-  python3 tools/on_this_day.py --pretty                 # indented JSON array output
+  python3 tools/on_this_day.py --no-approximate              # exclude approximate-precision events
+  python3 tools/on_this_day.py --include-year                # include year-only events
+  python3 tools/on_this_day.py --include-hermit-anniversaries  # add hermit join/YT anniversaries
+  python3 tools/on_this_day.py --pretty                      # indented JSON array output
 
 Date precision handling
 -----------------------
@@ -37,11 +38,13 @@ Exit codes
 
 import argparse
 import json
+import re
 import sys
-from datetime import date, timedelta
+from datetime import date
 from pathlib import Path
 
 EVENTS_FILE = Path(__file__).parent.parent / "knowledge" / "timelines" / "events.json"
+HERMITS_DIR = Path(__file__).parent.parent / "knowledge" / "hermits"
 
 # Day-of-year matching window in days (default)
 DEFAULT_WINDOW = 7
@@ -169,6 +172,123 @@ def find_on_this_day(
     return sorted(results, key=sort_key)
 
 
+def _parse_frontmatter(content: str) -> dict[str, str]:
+    """
+    Extract flat scalar fields from YAML frontmatter delimited by ``---``.
+
+    Only handles simple ``key: value`` lines (no lists, no nested mappings).
+    Quoted values have their surrounding quotes stripped.
+    """
+    if not content.startswith("---"):
+        return {}
+    end = content.find("\n---", 3)
+    if end == -1:
+        return {}
+    fm_text = content[4:end]
+    result: dict[str, str] = {}
+    for line in fm_text.splitlines():
+        # Skip list items, indented lines, and blank lines
+        if not line or line.startswith(" ") or line.startswith("-"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, raw_value = line.partition(":")
+        value = raw_value.strip().strip('"').strip("'")
+        if value:
+            result[key.strip()] = value
+    return result
+
+
+def _infer_precision(date_str: str) -> str:
+    """Infer date_precision from a date string (YYYY, YYYY-MM, or YYYY-MM-DD)."""
+    parts = date_str.split("-")
+    if len(parts) == 3:
+        return "day"
+    if len(parts) == 2:
+        return "month"
+    return "year"
+
+
+def load_hermit_profiles(directory: Path = HERMITS_DIR) -> list[dict[str, str]]:
+    """
+    Scan ``knowledge/hermits/*.md`` and return a list of frontmatter dicts
+    for profiles that have at least a ``name`` field.
+    """
+    profiles: list[dict[str, str]] = []
+    if not directory.exists():
+        return profiles
+    for path in sorted(directory.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        try:
+            fm = _parse_frontmatter(path.read_text())
+        except OSError:
+            continue
+        if fm.get("name"):
+            profiles.append(fm)
+    return profiles
+
+
+def synthesise_hermit_events(profiles: list[dict[str, str]]) -> list[dict]:
+    """
+    Build virtual event dicts from hermit profile frontmatter fields:
+
+    * ``join_date``         → "``{Name}`` Joins Hermitcraft" milestone
+    * ``yt_channel_start``  → "``{Name}`` Starts YouTube Channel" milestone
+
+    Synthesised events carry ``"source": "hermit_profile"`` so callers can
+    distinguish them from timeline data.
+    """
+    events: list[dict] = []
+    for fm in profiles:
+        name = fm.get("name", "")
+        slug = re.sub(r"[^a-z0-9]", "", name.lower())
+        joined_season_raw = fm.get("joined_season", "0")
+        try:
+            joined_season = int(joined_season_raw)
+        except ValueError:
+            joined_season = 0
+
+        join_date = fm.get("join_date", "")
+        if join_date:
+            precision = _infer_precision(join_date)
+            year_str = join_date.split("-")[0]
+            season_label = f"Season {joined_season}" if joined_season else "Hermitcraft"
+            events.append({
+                "id": f"hermit-{slug}-join",
+                "date": join_date,
+                "date_precision": precision,
+                "season": joined_season,
+                "hermits": [name],
+                "type": "milestone",
+                "title": f"{name} Joins Hermitcraft",
+                "description": (
+                    f"{name} joins Hermitcraft for the first time in {season_label} ({year_str})."
+                ),
+                "source": "hermit_profile",
+            })
+
+        yt_start = fm.get("yt_channel_start", "")
+        if yt_start:
+            precision = _infer_precision(yt_start)
+            events.append({
+                "id": f"hermit-{slug}-yt",
+                "date": yt_start,
+                "date_precision": precision,
+                "season": 0,
+                "hermits": [name],
+                "type": "milestone",
+                "title": f"{name} Starts YouTube Channel",
+                "description": (
+                    f"{name} creates their YouTube channel ({yt_start}),"
+                    " later becoming a member of Hermitcraft."
+                ),
+                "source": "hermit_profile",
+            })
+
+    return events
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="On This Day in Hermitcraft — historical event digest",
@@ -197,6 +317,13 @@ def main(argv: list[str] | None = None) -> int:
         help="Include events that only have year-level precision.",
     )
     parser.add_argument(
+        "--include-hermit-anniversaries", action="store_true", default=False,
+        help=(
+            "Synthesise hermit join and YouTube-channel anniversary events "
+            "from hermit profiles and include them in results."
+        ),
+    )
+    parser.add_argument(
         "--pretty", action="store_true",
         help="Output a pretty-printed JSON array instead of NDJSON.",
     )
@@ -218,6 +345,10 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     events = load_events()
+
+    if args.include_hermit_anniversaries:
+        profiles = load_hermit_profiles()
+        events = events + synthesise_hermit_events(profiles)
 
     results = find_on_this_day(
         events,


### PR DESCRIPTION
## Summary

- Adds `join_date` and `yt_channel_start` fields to **20 hermit profiles** in `knowledge/hermits/` (well above the ≥10 acceptance criterion)
- Extends `tools/on_this_day.py` with three new functions: `_parse_frontmatter`, `load_hermit_profiles`, and `synthesise_hermit_events`
- New `--include-hermit-anniversaries` CLI flag synthesises virtual milestone events from profile data and merges them into the daily digest output, sorted alongside regular timeline events

## Example output — April 13 with anniversaries

```
$ python3 tools/on_this_day.py --month 4 --day 13 --window 0 --include-hermit-anniversaries
{"id":"hermit-hypnotizd-join","date":"2012-04-13","title":"Hypnotizd Joins Hermitcraft","source":"hermit_profile",...}
{"id":"hermit-keralis-join",  "date":"2012-04-13","title":"Keralis Joins Hermitcraft",  "source":"hermit_profile",...}
{"id":"hermit-xisumavoid-join","date":"2012-04-13","title":"Xisumavoid Joins Hermitcraft","source":"hermit_profile",...}
{"id":"s1-001","date":"2012-04-13","title":"Hermitcraft Server Founded",...}
{"id":"s5-001","date":"2017-04-13","title":"Season 5 Launch",...}
```

## Acceptance criteria

- [x] 20 hermit profiles have a `join_date` field (≥10 required)
- [x] `--include-hermit-anniversaries` surfaces hermit join events on their join-date query
- [x] All existing 49 tests still pass; 26 new tests added (75 total)

## New hermit profiles with join_date

Xisumavoid, Keralis, Hypnotizd (2012-04-13), BdoubleO100 (2013-01-05), MumboJumbo / iJevin / xBCrafted (2013), TangoTek / FalseSymmetry / ZombieCleo (2014), Docm77 / ImpulseSV (2014-10), EthosLab (2015-03), GoodTimesWithScar / Iskall85 (2016-03), VintageBeef (2016), StressMonster101 / Zedaph (2017-04), Grian (2018-07-19), PearlescentMoon (2021)

## Test results

```
Ran 75 tests in 0.189s — OK
```

Closes #49