### PR TITLE
[hermitcraft-agent] Add rate-limit retry with exponential backoff to GitHub API calls

### DIFF
--- a/tests/test_api_retry.py
+++ b/tests/test_api_retry.py
@@ -1,0 +1,259 @@
+"""
+Tests for tools/api_retry.py
+
+Covers:
+  - is_rate_limited() detection for all known signal strings
+  - run_with_retry() success path (no sleep)
+  - run_with_retry() rate-limit path: retries, backoff values, log messages
+  - run_with_retry() exhaustion: returns last result after max_retries
+  - run_with_retry() non-rate-limit failure: no retry
+  - Backoff cap: sleep never exceeds max_wait
+  - pr_diff_fetcher.run() delegates to run_with_retry (integration smoke-test)
+"""
+
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+from tools.api_retry import (
+    BACKOFF_FACTOR,
+    INITIAL_WAIT,
+    MAX_RETRIES,
+    MAX_WAIT,
+    RATE_LIMIT_SIGNALS,
+    is_rate_limited,
+    run_with_retry,
+)
+
+
+# ── is_rate_limited ────────────────────────────────────────────────────────────
+
+class TestIsRateLimited(unittest.TestCase):
+
+    def test_empty_stderr_not_rate_limited(self):
+        self.assertFalse(is_rate_limited(""))
+
+    def test_generic_error_not_rate_limited(self):
+        self.assertFalse(is_rate_limited("error: repository not found"))
+
+    def test_rate_limit_phrase_detected(self):
+        self.assertTrue(is_rate_limited("error: rate limit exceeded for this resource"))
+
+    def test_429_detected(self):
+        self.assertTrue(is_rate_limited("HTTP 429: too many requests"))
+
+    def test_secondary_rate_detected(self):
+        self.assertTrue(is_rate_limited("You have triggered an abuse detection mechanism. "
+                                        "secondary rate limit applied."))
+
+    def test_too_many_requests_detected(self):
+        self.assertTrue(is_rate_limited("too many requests, please slow down"))
+
+    def test_api_rate_detected(self):
+        self.assertTrue(is_rate_limited("API rate limit exceeded for user ID 12345"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(is_rate_limited("RATE LIMIT EXCEEDED"))
+        self.assertTrue(is_rate_limited("Rate_Limit"))
+
+    def test_you_have_exceeded_detected(self):
+        self.assertTrue(is_rate_limited("You have exceeded the GitHub API rate limit"))
+
+    def test_abuse_detection_detected(self):
+        self.assertTrue(is_rate_limited("abuse detection mechanism triggered"))
+
+    def test_all_signals_covered(self):
+        """Every entry in RATE_LIMIT_SIGNALS should be detectable."""
+        for signal in RATE_LIMIT_SIGNALS:
+            with self.subTest(signal=signal):
+                self.assertTrue(is_rate_limited(signal))
+
+
+# ── run_with_retry — success path ──────────────────────────────────────────────
+
+class TestRunWithRetrySuccess(unittest.TestCase):
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_success_on_first_attempt_no_sleep(self, mock_sleep, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="output", stderr="")
+        rc, stdout, stderr = run_with_retry(["gh", "api", "test"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "output")
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_non_rate_limit_failure_no_retry(self, mock_sleep, mock_run):
+        """A plain error (non-429) must not trigger any retry."""
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="error: repository not found"
+        )
+        rc, stdout, stderr = run_with_retry(["gh", "pr", "diff", "99"])
+        self.assertEqual(rc, 1)
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
+
+
+# ── run_with_retry — rate-limit retry path ────────────────────────────────────
+
+class TestRunWithRetryRateLimit(unittest.TestCase):
+
+    def _rate_limited_result(self):
+        return MagicMock(returncode=1, stdout="", stderr="rate limit exceeded")
+
+    def _success_result(self):
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_retries_once_then_succeeds(self, mock_sleep, mock_run):
+        mock_run.side_effect = [self._rate_limited_result(), self._success_result()]
+        rc, stdout, _ = run_with_retry(["gh", "api", "x"], max_retries=5, initial_wait=1)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "ok")
+        self.assertEqual(mock_run.call_count, 2)
+        mock_sleep.assert_called_once_with(1)  # waited 1 s before retry
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_retries_up_to_max_retries(self, mock_sleep, mock_run):
+        """Fails max_retries+1 times → max_retries sleeps, last result returned."""
+        always_rate_limited = [self._rate_limited_result()] * (MAX_RETRIES + 1)
+        mock_run.side_effect = always_rate_limited
+        rc, _, _ = run_with_retry(["gh", "api", "x"])
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(mock_run.call_count, MAX_RETRIES + 1)
+        self.assertEqual(mock_sleep.call_count, MAX_RETRIES)
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_does_not_exceed_max_retries(self, mock_sleep, mock_run):
+        """Never calls subprocess.run more than max_retries+1 times."""
+        mock_run.return_value = self._rate_limited_result()
+        run_with_retry(["gh", "api", "x"], max_retries=3)
+        self.assertEqual(mock_run.call_count, 4)   # 1 initial + 3 retries
+        self.assertEqual(mock_sleep.call_count, 3)
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_backoff_sequence_doubles(self, mock_sleep, mock_run):
+        """Sleep durations should double: 1, 2, 4, 8, 16 (capped at 30)."""
+        mock_run.return_value = self._rate_limited_result()
+        run_with_retry(["gh", "api", "x"],
+                       max_retries=5, initial_wait=1, backoff_factor=2, max_wait=30)
+        expected_sleeps = [call(1), call(2), call(4), call(8), call(16)]
+        mock_sleep.assert_has_calls(expected_sleeps)
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_backoff_capped_at_max_wait(self, mock_sleep, mock_run):
+        """No sleep call should exceed max_wait."""
+        mock_run.return_value = self._rate_limited_result()
+        run_with_retry(["gh", "api", "x"],
+                       max_retries=5, initial_wait=10, backoff_factor=4, max_wait=30)
+        for c in mock_sleep.call_args_list:
+            sleep_duration = c.args[0]
+            self.assertLessEqual(sleep_duration, 30,
+                                 f"Sleep {sleep_duration}s exceeds max_wait=30s")
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_retry_logs_to_stderr(self, mock_sleep, mock_run):
+        """Each retry should log a message with the wait duration and attempt number."""
+        mock_run.side_effect = [self._rate_limited_result(), self._success_result()]
+        captured = StringIO()
+        with patch("tools.api_retry.sys.stderr", captured):
+            run_with_retry(["gh", "api", "x"], max_retries=5, initial_wait=1)
+        log = captured.getvalue()
+        self.assertIn("[api_retry]", log)
+        self.assertIn("rate limit", log)
+        self.assertIn("1/5", log)   # attempt 1 of 5
+        self.assertIn("1s", log)    # wait duration
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_retry_log_shows_correct_attempt_numbers(self, mock_sleep, mock_run):
+        """Log lines should show ascending attempt numbers."""
+        mock_run.return_value = self._rate_limited_result()
+        captured = StringIO()
+        with patch("tools.api_retry.sys.stderr", captured):
+            run_with_retry(["gh", "api", "x"], max_retries=3, initial_wait=1)
+        log = captured.getvalue()
+        self.assertIn("1/3", log)
+        self.assertIn("2/3", log)
+        self.assertIn("3/3", log)
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_zero_retries_returns_immediately(self, mock_sleep, mock_run):
+        """max_retries=0 should try once and return, never sleep."""
+        mock_run.return_value = self._rate_limited_result()
+        rc, _, _ = run_with_retry(["gh", "api", "x"], max_retries=0)
+        self.assertNotEqual(rc, 0)
+        mock_run.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("tools.api_retry.subprocess.run")
+    @patch("tools.api_retry.time.sleep")
+    def test_returns_last_result_after_exhaustion(self, mock_sleep, mock_run):
+        """After all retries, the final (rate-limited) result is returned."""
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="rate limit exceeded — final"
+        )
+        rc, _, stderr = run_with_retry(["gh", "api", "x"], max_retries=2)
+        self.assertEqual(rc, 1)
+        self.assertIn("rate limit", stderr)
+
+
+# ── module constants sanity ───────────────────────────────────────────────────
+
+class TestConstants(unittest.TestCase):
+
+    def test_max_retries_is_5(self):
+        self.assertEqual(MAX_RETRIES, 5)
+
+    def test_initial_wait_is_1_second(self):
+        self.assertEqual(INITIAL_WAIT, 1.0)
+
+    def test_backoff_factor_is_2(self):
+        self.assertEqual(BACKOFF_FACTOR, 2.0)
+
+    def test_max_wait_is_30_seconds(self):
+        self.assertEqual(MAX_WAIT, 30.0)
+
+    def test_rate_limit_signals_non_empty(self):
+        self.assertGreater(len(RATE_LIMIT_SIGNALS), 0)
+
+
+# ── pr_diff_fetcher integration: run() delegates to run_with_retry ────────────
+
+class TestPrDiffFetcherUsesRetry(unittest.TestCase):
+
+    @patch("tools.pr_diff_fetcher.run_with_retry")
+    def test_run_delegates_to_run_with_retry(self, mock_retry):
+        """pr_diff_fetcher.run() must call run_with_retry, not subprocess.run directly."""
+        from tools.pr_diff_fetcher import run
+        mock_retry.return_value = (0, "stdout", "")
+        rc, stdout, stderr = run(["gh", "api", "test"], timeout=30)
+        mock_retry.assert_called_once_with(["gh", "api", "test"], timeout=30)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stdout, "stdout")
+
+    @patch("tools.pr_diff_fetcher.run_with_retry")
+    def test_run_passes_timeout(self, mock_retry):
+        from tools.pr_diff_fetcher import run
+        mock_retry.return_value = (0, "", "")
+        run(["gh", "pr", "diff", "42"], timeout=120)
+        _, kwargs = mock_retry.call_args
+        self.assertEqual(kwargs.get("timeout"), 120)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/api_retry.py
+++ b/tools/api_retry.py
@@ -1,0 +1,131 @@
+"""
+api_retry.py
+============
+Exponential-backoff retry wrapper for subprocess calls (primarily GitHub
+CLI ``gh`` commands) that may be throttled by a rate-limit response.
+
+Problem
+-------
+GitHub's REST API returns HTTP 429 or an "API rate limit exceeded" message
+when a client sends too many requests in a short window.  Without retry
+logic every agent tool that shells out to ``gh api`` / ``gh pr diff`` fails
+hard on the first throttled call, requiring a human or supervisor to
+re-dispatch the task.
+
+Strategy
+--------
+1. Run the command normally.
+2. If it exits non-zero *and* stderr contains a known rate-limit signal,
+   wait (1 s → 2 s → 4 s → 8 s → 16 s, capped at 30 s) and retry.
+3. Log each retry attempt to stderr so operators can monitor backoff
+   behaviour without inspecting internal state.
+4. After exhausting *max_retries* attempts, return the last result
+   (non-zero exit code) so callers can decide how to handle final failure.
+
+Usage
+-----
+    from tools.api_retry import run_with_retry
+
+    rc, stdout, stderr = run_with_retry(["gh", "api", "repos/owner/repo"])
+    if rc != 0:
+        # all retries exhausted or non-rate-limit error
+        raise RuntimeError(stderr)
+
+Exit conventions (same as subprocess.run)
+-----------------------------------------
+    0   — success
+    non-zero — command failed (after all retries if rate-limited)
+
+Constants (all overridable per-call)
+-------------------------------------
+    MAX_RETRIES    = 5     retry attempts after the first failure
+    INITIAL_WAIT   = 1.0   seconds before first retry
+    BACKOFF_FACTOR = 2     multiplier applied after each retry
+    MAX_WAIT       = 30    seconds ceiling on any single sleep
+"""
+
+import subprocess
+import sys
+import time
+
+# ── tuneable defaults ──────────────────────────────────────────────────────────
+
+MAX_RETRIES: int = 5
+INITIAL_WAIT: float = 1.0   # seconds
+BACKOFF_FACTOR: float = 2.0
+MAX_WAIT: float = 30.0      # seconds
+
+# Substrings that indicate a GitHub API rate-limit response (case-insensitive).
+RATE_LIMIT_SIGNALS: tuple[str, ...] = (
+    "rate limit",
+    "rate_limit",
+    "429",
+    "secondary rate",
+    "api rate",
+    "too many requests",
+    "you have exceeded",
+    "abuse detection",
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def is_rate_limited(stderr: str) -> bool:
+    """Return True if *stderr* text looks like a GitHub rate-limit response."""
+    lower = stderr.lower()
+    return any(signal in lower for signal in RATE_LIMIT_SIGNALS)
+
+
+# ── public API ─────────────────────────────────────────────────────────────────
+
+def run_with_retry(
+    cmd: list,
+    timeout: int = 60,
+    max_retries: int = MAX_RETRIES,
+    initial_wait: float = INITIAL_WAIT,
+    backoff_factor: float = BACKOFF_FACTOR,
+    max_wait: float = MAX_WAIT,
+) -> tuple[int, str, str]:
+    """
+    Run *cmd* as a subprocess and return ``(returncode, stdout, stderr)``.
+
+    If the command fails with a rate-limit signal in stderr, retry up to
+    *max_retries* times with exponential backoff, logging each attempt.
+
+    Parameters
+    ----------
+    cmd:           Command and arguments list, passed to ``subprocess.run``.
+    timeout:       Per-attempt timeout in seconds (default 60).
+    max_retries:   Maximum number of retry attempts after first failure (default 5).
+    initial_wait:  Seconds to wait before first retry (default 1.0).
+    backoff_factor: Multiplier applied to wait after each retry (default 2.0).
+    max_wait:      Ceiling on any single sleep duration in seconds (default 30.0).
+
+    Returns
+    -------
+    (returncode, stdout, stderr) of the last attempt.
+    """
+    wait = initial_wait
+
+    # attempt 1 is the initial try; attempts 2..max_retries+1 are retries
+    for attempt in range(1, max_retries + 2):
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        rc, stdout, stderr = result.returncode, result.stdout, result.stderr
+
+        # Success or non-rate-limit failure — return immediately, no retry
+        if rc == 0 or not is_rate_limited(stderr):
+            return rc, stdout, stderr
+
+        # Rate-limited.  Retry if attempts remain.
+        retries_used = attempt - 1
+        if retries_used < max_retries:
+            sleep_for = min(wait, max_wait)
+            sys.stderr.write(
+                f"[api_retry] rate limit detected, retrying in {sleep_for:.0f}s "
+                f"(attempt {retries_used + 1}/{max_retries})\n"
+            )
+            time.sleep(sleep_for)
+            wait = min(wait * backoff_factor, max_wait)
+
+    # All retries exhausted — return the last result
+    return rc, stdout, stderr

--- a/tools/pr_diff_fetcher.py
+++ b/tools/pr_diff_fetcher.py
@@ -34,6 +34,8 @@ import sys
 from dataclasses import dataclass, asdict
 from typing import Optional
 
+from tools.api_retry import run_with_retry
+
 # Threshold above which we switch to per-file mode (100 KB)
 DIFF_TRUNCATION_THRESHOLD = 100_000
 
@@ -63,9 +65,14 @@ class DiffReport:
 
 
 def run(cmd: list, timeout: int = 60) -> tuple[int, str, str]:
-    """Run a subprocess, return (returncode, stdout, stderr)."""
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-    return result.returncode, result.stdout, result.stderr
+    """Run a subprocess with automatic rate-limit retry.
+
+    Delegates to ``api_retry.run_with_retry`` so that GitHub API calls
+    throttled with HTTP 429 / rate-limit responses are retried with
+    exponential backoff (up to 5 times, 1 s → 2 s → 4 s → 8 s → 16 s)
+    before surfacing a failure.
+    """
+    return run_with_retry(cmd, timeout=timeout)
 
 
 def fetch_unified_diff(repo: str, pr: int) -> tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
Closes #65

## Summary

- Adds **`tools/api_retry.py`** — a `run_with_retry()` wrapper that transparently retries `gh` CLI calls throttled by GitHub's rate limiter
- Wires `run_with_retry` into **`pr_diff_fetcher.run()`** so all GitHub API subprocess calls benefit automatically
- **29 new unit tests** in `tests/test_api_retry.py` — all tests pass

## Behaviour

| Scenario | Result |
|---|---|
| Command succeeds on first attempt | Returns immediately, no sleep |
| Non-rate-limit failure (e.g. repo not found) | Returns immediately, no retry |
| Rate-limit detected (`rate limit`, `429`, `secondary rate`, etc.) | Retries up to 5×, sleeps 1 s → 2 s → 4 s → 8 s → 16 s (cap 30 s) |
| All 5 retries exhausted | Returns last (failing) result so caller can handle |

Each retry logs to stderr:
```
[api_retry] rate limit detected, retrying in 2s (attempt 2/5)
```

## Rate-limit signals detected

`rate limit`, `rate_limit`, `429`, `secondary rate`, `api rate`, `too many requests`, `you have exceeded`, `abuse detection`

## Test plan

- [ ] `python3 -m unittest tests.test_api_retry` — 29 tests pass
- [ ] `python3 -m unittest tests.test_pr_diff_fetcher` — existing 32 tests still pass
- [ ] `python3 -m unittest tests.test_on_this_day` — 111 tests still pass