### PR TITLE
[hermitcraft-agent] docs: add pre-PR rebase step to workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@ This is a self-learning Hermitcraft knowledge agent. You (Claude) are the agent.
 - **All changes go through PRs.** Never commit directly to main.
 - **Every PR starts with a GitHub issue.** Create the issue first, then branch + PR.
 - **Branch naming:** `<type>/<short-description>` (e.g., `research/season-10-hermits`, `fix/grian-spelling`)
+- **Rebase on main before opening a PR.** Immediately before running `gh pr create`, always run:
+  ```
+  git fetch origin
+  git rebase origin/main
+  ```
+  This prevents merge conflicts from accumulating and keeps the PR diff clean.
 - **The orchestrator reviews PRs** via comments on the same GitHub account. Address all comments before merging.
 - **Keep PRs focused.** One topic or improvement per PR.
 


### PR DESCRIPTION
## Summary

- Adds a mandatory **rebase on main before opening a PR** step to the Workflow Rules section of `CLAUDE.md`
- The rule instructs agents to run `git fetch origin && git rebase origin/main` immediately before `gh pr create`
- Prevents merge conflicts from accumulating when multiple feature branches are in flight simultaneously

## Motivation

Rebase-conflict tasks (#53, #54, #57) repeatedly appeared as separate issues because feature branches drifted from main while awaiting review. Making the pre-PR rebase a documented, required step eliminates this class of rework entirely.

## Test plan

- [ ] Read `CLAUDE.md` and confirm the new bullet appears under **Workflow Rules** between the branch-naming rule and the orchestrator-review rule
- [ ] Confirm the code block shows exactly `git fetch origin` then `git rebase origin/main`
- [ ] No code changes — docs-only PR; no tests required

Closes #71