### PR TITLE
[hermitcraft-agent] Add season_recap.py CLI for per-season digests

### DIFF
--- a/tests/test_season_recap.py
+++ b/tests/test_season_recap.py
@@ -1,0 +1,465 @@
+"""
+Tests for tools/season_recap.py
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Make tools importable from the project root
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.season_recap import (
+    _parse_frontmatter,
+    _parse_markdown_sections,
+    _extract_bullet_list,
+    _extract_members_from_text,
+    _extract_first_paragraph,
+    build_recap,
+    format_text,
+    load_season_file,
+    load_events_for_season,
+    SEASONS_DIR,
+    EVENTS_FILE,
+    KNOWN_SEASONS,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — frontmatter parser
+# ---------------------------------------------------------------------------
+
+class TestParseFrontmatter(unittest.TestCase):
+    def test_basic_scalar_fields(self):
+        content = '---\nseason: 7\nstatus: ended\n---\n'
+        fm = _parse_frontmatter(content)
+        self.assertEqual(fm['season'], '7')
+        self.assertEqual(fm['status'], 'ended')
+
+    def test_quoted_values_stripped(self):
+        content = '---\nstart_date: "2020-02-28"\n---\n'
+        fm = _parse_frontmatter(content)
+        self.assertEqual(fm['start_date'], '2020-02-28')
+
+    def test_no_frontmatter_returns_empty(self):
+        self.assertEqual(_parse_frontmatter('# No frontmatter'), {})
+
+    def test_unclosed_frontmatter_returns_empty(self):
+        self.assertEqual(_parse_frontmatter('---\nkey: val\n'), {})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — markdown section parser
+# ---------------------------------------------------------------------------
+
+class TestParseMarkdownSections(unittest.TestCase):
+    SAMPLE = (
+        '---\nseason: 1\n---\n'
+        '# Title\n\n'
+        '## Overview\n\nThis is the overview.\n\n'
+        '## Members\n\nAlice, Bob, Carol\n\n'
+        '## Notable Events\n\n- Event one\n- Event two\n'
+    )
+
+    def test_overview_extracted(self):
+        sections = _parse_markdown_sections(self.SAMPLE)
+        self.assertIn('Overview', sections)
+        self.assertIn('overview', sections['Overview'].lower())
+
+    def test_members_extracted(self):
+        sections = _parse_markdown_sections(self.SAMPLE)
+        self.assertIn('Members', sections)
+        self.assertIn('Alice', sections['Members'])
+
+    def test_notable_events_extracted(self):
+        sections = _parse_markdown_sections(self.SAMPLE)
+        self.assertIn('Notable Events', sections)
+
+    def test_sections_without_frontmatter(self):
+        content = '## Section A\n\nBody A\n\n## Section B\n\nBody B\n'
+        sections = _parse_markdown_sections(content)
+        self.assertIn('Section A', sections)
+        self.assertIn('Section B', sections)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — bullet list extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractBulletList(unittest.TestCase):
+    def test_dash_bullets(self):
+        text = '- First item\n- Second item\n- Third item'
+        items = _extract_bullet_list(text)
+        self.assertEqual(items, ['First item', 'Second item', 'Third item'])
+
+    def test_star_bullets(self):
+        text = '* Alpha\n* Beta'
+        items = _extract_bullet_list(text)
+        self.assertEqual(items, ['Alpha', 'Beta'])
+
+    def test_empty_text(self):
+        self.assertEqual(_extract_bullet_list(''), [])
+
+    def test_no_bullets(self):
+        self.assertEqual(_extract_bullet_list('Just a paragraph.'), [])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — member extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractMembersFromText(unittest.TestCase):
+    def test_simple_comma_list(self):
+        text = 'Grian, MumboJumbo, Iskall85, TangoTek\n'
+        members = _extract_members_from_text(text)
+        self.assertIn('Grian', members)
+        self.assertIn('MumboJumbo', members)
+
+    def test_markdown_bold_stripped(self):
+        text = '**GeminiTay** *(new)*, Grian, MumboJumbo, Iskall85\n'
+        members = _extract_members_from_text(text)
+        self.assertIn('GeminiTay', members)
+        self.assertIn('Grian', members)
+
+    def test_lowercase_start_handles(self):
+        # iJevin and xBCrafted start with lowercase
+        text = 'Grian, iJevin, xBCrafted, MumboJumbo\n'
+        members = _extract_members_from_text(text)
+        self.assertIn('iJevin', members)
+        self.assertIn('xBCrafted', members)
+
+    def test_prose_line_skipped_for_better_roster(self):
+        # Prose line has fewer valid names than the actual roster
+        text = (
+            'All 24 Season 7 members returned, plus two new additions:\n\n'
+            'Grian, MumboJumbo, Iskall85, TangoTek, Scar, ImpulseSV\n'
+        )
+        members = _extract_members_from_text(text)
+        self.assertGreaterEqual(len(members), 6)
+        self.assertIn('Grian', members)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — first paragraph extractor
+# ---------------------------------------------------------------------------
+
+class TestExtractFirstParagraph(unittest.TestCase):
+    def test_returns_first_non_empty_line(self):
+        text = '\n\nSome intro text here.\n\nMore text.'
+        self.assertEqual(_extract_first_paragraph(text), 'Some intro text here.')
+
+    def test_skips_headings(self):
+        text = '## Heading\n\nActual paragraph.'
+        self.assertEqual(_extract_first_paragraph(text), 'Actual paragraph.')
+
+    def test_empty_text(self):
+        self.assertEqual(_extract_first_paragraph(''), '')
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — load_season_file and load_events_for_season
+# ---------------------------------------------------------------------------
+
+class TestLoadSeasonFile(unittest.TestCase):
+    def test_season_7_loads(self):
+        fm, sections = load_season_file(7)
+        self.assertEqual(fm.get('season'), '7')
+        self.assertIn('Overview', sections)
+
+    def test_season_9_start_date(self):
+        fm, _ = load_season_file(9)
+        self.assertEqual(fm.get('start_date'), '2022-03-05')
+
+    def test_missing_season_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            load_season_file(999)
+
+    def test_all_known_seasons_loadable(self):
+        for s in KNOWN_SEASONS:
+            path = SEASONS_DIR / f'season-{s}.md'
+            if path.exists():
+                fm, sections = load_season_file(s)
+                self.assertIsInstance(fm, dict)
+                self.assertIsInstance(sections, dict)
+
+
+class TestLoadEventsForSeason(unittest.TestCase):
+    def test_season_7_has_events(self):
+        events = load_events_for_season(7)
+        self.assertGreater(len(events), 0)
+
+    def test_all_events_correct_season(self):
+        for s in [6, 7, 8, 9]:
+            events = load_events_for_season(s)
+            for ev in events:
+                self.assertEqual(ev.get('season'), s)
+
+    def test_nonexistent_season_returns_empty(self):
+        events = load_events_for_season(9999)
+        self.assertEqual(events, [])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — build_recap
+# ---------------------------------------------------------------------------
+
+class TestBuildRecap(unittest.TestCase):
+    def _recap(self, season: int) -> dict:
+        return build_recap(season)
+
+    def test_season_field_correct(self):
+        self.assertEqual(self._recap(7)['season'], 7)
+        self.assertEqual(self._recap(9)['season'], 9)
+
+    def test_required_keys_present(self):
+        required = [
+            'season', 'start_date', 'end_date', 'minecraft_version',
+            'member_count', 'theme', 'status', 'overview', 'members',
+            'key_themes', 'notable_events', 'major_builds', 'sources',
+            'timeline_events',
+        ]
+        recap = self._recap(7)
+        for key in required:
+            self.assertIn(key, recap, f"Missing key: {key}")
+
+    def test_season_7_start_date(self):
+        self.assertEqual(self._recap(7)['start_date'], '2020-02-28')
+
+    def test_season_8_start_date(self):
+        self.assertEqual(self._recap(8)['start_date'], '2021-06-19')
+
+    def test_season_9_longest(self):
+        recap = self._recap(9)
+        # Duration text should mention months
+        self.assertIn('month', recap.get('duration', '').lower())
+
+    def test_season_7_has_members(self):
+        members = self._recap(7)['members']
+        self.assertGreater(len(members), 0)
+        self.assertIn('Grian', members)
+
+    def test_season_8_includes_lowercase_handles(self):
+        members = self._recap(8)['members']
+        self.assertIn('iJevin', members)
+        self.assertIn('xBCrafted', members)
+
+    def test_season_9_member_count(self):
+        recap = self._recap(9)
+        self.assertEqual(recap['member_count'], 26)
+
+    def test_season_7_seed(self):
+        self.assertEqual(self._recap(7)['seed'], '-2143500864')
+
+    def test_season_9_unknown_seed_is_none(self):
+        self.assertIsNone(self._recap(9)['seed'])
+
+    def test_season_7_has_timeline_events(self):
+        self.assertGreater(len(self._recap(7)['timeline_events']), 0)
+
+    def test_season_7_has_notable_events(self):
+        self.assertGreater(len(self._recap(7)['notable_events']), 0)
+
+    def test_season_7_has_major_builds(self):
+        self.assertGreater(len(self._recap(7)['major_builds']), 0)
+
+    def test_season_7_has_sources(self):
+        sources = self._recap(7)['sources']
+        self.assertGreater(len(sources), 0)
+        self.assertTrue(any('hermitcraft' in s.lower() for s in sources))
+
+    def test_season_7_overview_non_empty(self):
+        self.assertTrue(self._recap(7)['overview'])
+
+    def test_seasons_7_8_9_covered(self):
+        for s in [7, 8, 9]:
+            recap = build_recap(s)
+            self.assertGreater(len(recap['members']), 0,
+                               f"Season {s} has no members")
+            self.assertGreater(len(recap['timeline_events']), 0,
+                               f"Season {s} has no timeline events")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — format_text
+# ---------------------------------------------------------------------------
+
+class TestFormatText(unittest.TestCase):
+    def setUp(self):
+        self.recap7 = build_recap(7)
+        self.recap9 = build_recap(9)
+
+    def test_output_is_string(self):
+        self.assertIsInstance(format_text(self.recap7), str)
+
+    def test_season_number_in_output(self):
+        out = format_text(self.recap7)
+        self.assertIn('SEASON 7', out)
+
+    def test_dates_in_output(self):
+        out = format_text(self.recap7)
+        self.assertIn('2020-02-28', out)
+
+    def test_members_section_present(self):
+        out = format_text(self.recap7)
+        self.assertIn('MEMBERS', out)
+
+    def test_notable_events_section_present(self):
+        out = format_text(self.recap7)
+        self.assertIn('NOTABLE EVENTS', out)
+
+    def test_timeline_section_present(self):
+        out = format_text(self.recap7)
+        self.assertIn('TIMELINE', out)
+
+    def test_sources_section_present(self):
+        out = format_text(self.recap7)
+        self.assertIn('SOURCES', out)
+
+    def test_empty_recap_does_not_crash(self):
+        # A minimal recap with no optional sections should not raise
+        minimal = {
+            'season': 99, 'start_date': '', 'end_date': '', 'duration': '',
+            'minecraft_version': '', 'member_count': 0, 'seed': None,
+            'theme': '', 'status': '', 'overview': '', 'members': [],
+            'key_themes': [], 'notable_events': [], 'major_builds': [],
+            'sources': [], 'timeline_events': [],
+        }
+        out = format_text(minimal)
+        self.assertIn('SEASON 99', out)
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+SCRIPT = str(Path(__file__).parent.parent / 'tools' / 'season_recap.py')
+
+
+class TestCLI(unittest.TestCase):
+    def _run(self, *args: str) -> tuple[int, str, str]:
+        result = subprocess.run(
+            [sys.executable, SCRIPT, *args],
+            capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def test_season_7_exits_0(self):
+        rc, _, _ = self._run('--season', '7')
+        self.assertEqual(rc, 0)
+
+    def test_season_9_exits_0(self):
+        rc, _, _ = self._run('--season', '9')
+        self.assertEqual(rc, 0)
+
+    def test_text_output_contains_recap_header(self):
+        _, stdout, _ = self._run('--season', '7')
+        self.assertIn('SEASON 7', stdout)
+
+    def test_json_flag_produces_valid_json(self):
+        rc, stdout, _ = self._run('--season', '9', '--json')
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertEqual(data['season'], 9)
+
+    def test_json_output_has_required_fields(self):
+        _, stdout, _ = self._run('--season', '7', '--json')
+        data = json.loads(stdout)
+        for key in ('season', 'start_date', 'members', 'notable_events',
+                    'timeline_events', 'sources'):
+            self.assertIn(key, data)
+
+    def test_unknown_season_exits_2(self):
+        rc, _, stderr = self._run('--season', '99')
+        self.assertEqual(rc, 2)
+        self.assertIn('unknown season', stderr)
+
+    def test_missing_arguments_exits_nonzero(self):
+        rc, _, _ = self._run()
+        self.assertNotEqual(rc, 0)
+
+    def test_list_flag_exits_0(self):
+        rc, stdout, _ = self._run('--list')
+        self.assertEqual(rc, 0)
+        self.assertIn('1', stdout)
+        self.assertIn('11', stdout)
+
+    def test_list_json_flag(self):
+        rc, stdout, _ = self._run('--list', '--json')
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertIn('available_seasons', data)
+        self.assertIn(7, data['available_seasons'])
+
+    def test_season_8_members_include_new(self):
+        _, stdout, _ = self._run('--season', '8', '--json')
+        data = json.loads(stdout)
+        members = data['members']
+        self.assertIn('GeminiTay', members)
+        self.assertIn('PearlescentMoon', members)
+
+    def test_season_9_json_member_count(self):
+        _, stdout, _ = self._run('--season', '9', '--json')
+        data = json.loads(stdout)
+        self.assertEqual(data['member_count'], 26)
+
+
+# ---------------------------------------------------------------------------
+# KNOWN_SEASONS constant
+# ---------------------------------------------------------------------------
+
+class TestConstants(unittest.TestCase):
+    def test_known_seasons_is_list(self):
+        self.assertIsInstance(KNOWN_SEASONS, list)
+
+    def test_known_seasons_includes_7_8_9(self):
+        for s in [7, 8, 9]:
+            self.assertIn(s, KNOWN_SEASONS)
+
+    def test_known_seasons_min_max(self):
+        self.assertEqual(min(KNOWN_SEASONS), 1)
+        self.assertGreaterEqual(max(KNOWN_SEASONS), 11)
+
+    def test_seasons_dir_exists(self):
+        self.assertTrue(SEASONS_DIR.exists(), f"SEASONS_DIR not found: {SEASONS_DIR}")
+
+    def test_events_file_exists(self):
+        self.assertTrue(EVENTS_FILE.exists(), f"EVENTS_FILE not found: {EVENTS_FILE}")
+
+
+if __name__ == '__main__':
+    # Custom runner matching on_this_day test style
+    import traceback
+
+    suites = [
+        ('_parse_frontmatter', unittest.TestLoader().loadTestsFromTestCase(TestParseFrontmatter)),
+        ('_parse_markdown_sections', unittest.TestLoader().loadTestsFromTestCase(TestParseMarkdownSections)),
+        ('_extract_bullet_list', unittest.TestLoader().loadTestsFromTestCase(TestExtractBulletList)),
+        ('_extract_members_from_text', unittest.TestLoader().loadTestsFromTestCase(TestExtractMembersFromText)),
+        ('_extract_first_paragraph', unittest.TestLoader().loadTestsFromTestCase(TestExtractFirstParagraph)),
+        ('load_season_file', unittest.TestLoader().loadTestsFromTestCase(TestLoadSeasonFile)),
+        ('load_events_for_season', unittest.TestLoader().loadTestsFromTestCase(TestLoadEventsForSeason)),
+        ('build_recap', unittest.TestLoader().loadTestsFromTestCase(TestBuildRecap)),
+        ('format_text', unittest.TestLoader().loadTestsFromTestCase(TestFormatText)),
+        ('CLI', unittest.TestLoader().loadTestsFromTestCase(TestCLI)),
+        ('constants', unittest.TestLoader().loadTestsFromTestCase(TestConstants)),
+    ]
+
+    total = passed = failed = 0
+    for label, suite in suites:
+        print(f'{label}:')
+        for test in suite:
+            total += 1
+            try:
+                test.debug()
+                print(f'  PASS {test._testMethodName}')
+                passed += 1
+            except Exception as exc:
+                print(f'  FAIL {test._testMethodName}: {exc}')
+                failed += 1
+
+    print(f'\n{passed} passed, {failed} failed')
+    sys.exit(0 if failed == 0 else 1)

--- a/tools/season_recap.py
+++ b/tools/season_recap.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""
+Season Recap
+============
+Output a rich digest for a given Hermitcraft season, pulling from
+the season markdown file and the shared events timeline.
+
+Usage
+-----
+  python3 tools/season_recap.py --season 9          # formatted text
+  python3 tools/season_recap.py --season 7 --json   # machine-readable JSON
+  python3 tools/season_recap.py --list               # list available seasons
+
+Output (text mode)
+------------------
+  Season header, dates, members, key themes, notable events, major builds,
+  and timeline events sourced from knowledge/timelines/events.json.
+
+Output (JSON mode)
+------------------
+  A single JSON object with all the same fields, suitable for consumption
+  by other tools or prompts.
+
+Exit codes
+----------
+  0  success
+  1  season not found or no data available
+  2  bad arguments or data file not found
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+SEASONS_DIR = Path(__file__).parent.parent / "knowledge" / "seasons"
+EVENTS_FILE = Path(__file__).parent.parent / "knowledge" / "timelines" / "events.json"
+
+# Seasons that have a corresponding markdown file
+KNOWN_SEASONS = list(range(1, 12))  # 1–11
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (mirrors on_this_day._parse_frontmatter)
+# ---------------------------------------------------------------------------
+
+def _parse_frontmatter(content: str) -> dict:
+    """Extract scalar fields from YAML frontmatter delimited by ``---``."""
+    if not content.startswith("---"):
+        return {}
+    end = content.find("\n---", 3)
+    if end == -1:
+        return {}
+    fm_text = content[4:end]
+    result: dict = {}
+    for line in fm_text.splitlines():
+        if not line.strip() or ":" not in line:
+            continue
+        key, _, raw_value = line.partition(":")
+        value = raw_value.strip().strip('"').strip("'")
+        if value:
+            result[key.strip()] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Markdown section parser
+# ---------------------------------------------------------------------------
+
+def _parse_markdown_sections(content: str) -> dict[str, str]:
+    """
+    Split the markdown body (after frontmatter) into a dict of
+    {section_title: section_body} based on ``## `` level-2 headings.
+    """
+    # Strip frontmatter block
+    if content.startswith("---"):
+        end = content.find("\n---", 3)
+        if end != -1:
+            content = content[end + 4:]
+
+    sections: dict[str, str] = {}
+    current_title: str | None = None
+    current_lines: list[str] = []
+
+    for line in content.splitlines():
+        if line.startswith("## "):
+            if current_title is not None:
+                sections[current_title] = "\n".join(current_lines).strip()
+            current_title = line[3:].strip()
+            current_lines = []
+        else:
+            if current_title is not None:
+                current_lines.append(line)
+
+    if current_title is not None:
+        sections[current_title] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def _extract_bullet_list(text: str) -> list[str]:
+    """
+    Return a list of bullet point strings from a markdown section body.
+    Handles both ``- `` and ``* `` bullets, stripping leading marker.
+    Continuation lines (not starting with ``-``/``*``) are appended to the
+    previous item.
+    """
+    items: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- ") or stripped.startswith("* "):
+            items.append(stripped[2:].strip())
+        elif stripped and items:
+            # Continuation line — append to previous item
+            items[-1] = items[-1] + " " + stripped
+    return items
+
+
+def _extract_members_from_text(text: str) -> list[str]:
+    """
+    Parse the Members section text into a list of member name strings.
+    Handles the comma-separated paragraph format used in season files,
+    stripping markdown bold/italic markers and footnotes like *(new)*.
+
+    Strategy: find the line with the most comma-separated tokens that look
+    like proper names (capitalised words, ≥3 chars), since prose lines like
+    "All 24 Season 7 members returned, plus two new additions:" also contain
+    commas but yield very few valid names.
+    """
+    # Strip markdown formatting
+    clean = re.sub(r"\*\([^)]*\)\*", "", text)   # *(returned)*, *(new)*
+    clean = re.sub(r"\*\*([^*]+)\*\*", r"\1", clean)  # **bold**
+    clean = re.sub(r"\*([^*]+)\*", r"\1", clean)       # *italic*
+
+    def _is_name_like(token: str) -> bool:
+        t = token.strip().strip("*").strip()
+        if not t or len(t) < 2:
+            return False
+        # Accept names that start uppercase OR contain at least one uppercase
+        # (handles hermit handles like iJevin, xBCrafted that start lowercase)
+        return t[0].isupper() or any(c.isupper() for c in t[1:])
+
+    best_line_members: list[str] = []
+    for line in clean.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("|"):
+            continue
+        if "," not in line:
+            continue
+        candidates = [t.strip() for t in line.split(",")]
+        name_candidates = [t for t in candidates if _is_name_like(t)]
+        if len(name_candidates) > len(best_line_members):
+            best_line_members = name_candidates
+
+    return best_line_members
+
+
+def _extract_first_paragraph(text: str) -> str:
+    """Return the first non-empty, non-heading paragraph from a markdown block."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and not stripped.startswith("|"):
+            return stripped
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Data loaders
+# ---------------------------------------------------------------------------
+
+def load_season_file(season: int) -> tuple[dict, dict[str, str]]:
+    """
+    Load ``knowledge/seasons/season-N.md`` and return
+    ``(frontmatter_dict, sections_dict)``.
+
+    Raises ``FileNotFoundError`` if the file does not exist.
+    """
+    path = SEASONS_DIR / f"season-{season}.md"
+    if not path.exists():
+        raise FileNotFoundError(f"Season file not found: {path}")
+    content = path.read_text(encoding="utf-8")
+    frontmatter = _parse_frontmatter(content)
+    sections = _parse_markdown_sections(content)
+    return frontmatter, sections
+
+
+def load_events_for_season(season: int) -> list[dict]:
+    """
+    Load ``knowledge/timelines/events.json`` and return only events
+    whose ``season`` field equals *season*.
+    """
+    if not EVENTS_FILE.exists():
+        return []
+    try:
+        with EVENTS_FILE.open(encoding="utf-8") as fh:
+            all_events: list[dict] = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return []
+    return [e for e in all_events if e.get("season") == season]
+
+
+# ---------------------------------------------------------------------------
+# Recap assembler
+# ---------------------------------------------------------------------------
+
+def build_recap(season: int) -> dict:
+    """
+    Build and return the full recap dict for *season*.
+
+    Keys
+    ----
+    season, start_date, end_date, duration, minecraft_version,
+    member_count, seed, theme, status, overview, members,
+    key_themes, notable_events, major_builds, sources, timeline_events
+    """
+    frontmatter, sections = load_season_file(season)
+
+    overview_text = sections.get("Overview", "")
+    overview = _extract_first_paragraph(overview_text)
+
+    members_text = sections.get("Members", "")
+    members = _extract_members_from_text(members_text)
+
+    key_themes = _extract_bullet_list(sections.get("Key Themes", ""))
+    notable_events = _extract_bullet_list(sections.get("Notable Events", ""))
+    major_builds = _extract_bullet_list(sections.get("Major Builds", ""))
+
+    # Sources: extract URLs from the Sources section
+    sources_text = sections.get("Sources", "")
+    sources = re.findall(r"https?://[^\s\)]+", sources_text)
+
+    # Duration: parse from the dates table if present; fall back to frontmatter
+    duration = ""
+    dates_text = sections.get("Dates", "")
+    duration_match = re.search(r"\|\s*\*\*Duration\*\*\s*\|\s*([^|]+)\|", dates_text)
+    if duration_match:
+        duration = duration_match.group(1).strip()
+
+    timeline_events = load_events_for_season(season)
+
+    seed = frontmatter.get("seed", "")
+    if seed.lower() == "unknown":
+        seed = None
+
+    return {
+        "season": season,
+        "start_date": frontmatter.get("start_date", ""),
+        "end_date": frontmatter.get("end_date", ""),
+        "duration": duration,
+        "minecraft_version": frontmatter.get("minecraft_version", ""),
+        "member_count": int(frontmatter.get("member_count", 0) or 0),
+        "seed": seed,
+        "theme": frontmatter.get("theme", ""),
+        "status": frontmatter.get("status", ""),
+        "overview": overview,
+        "members": members,
+        "key_themes": key_themes,
+        "notable_events": notable_events,
+        "major_builds": major_builds,
+        "sources": sources,
+        "timeline_events": timeline_events,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Text formatter
+# ---------------------------------------------------------------------------
+
+def _hr(char: str = "─", width: int = 60) -> str:
+    return char * width
+
+
+def format_text(recap: dict) -> str:
+    """Return a human-readable multi-line string summarising the season."""
+    lines: list[str] = []
+    season = recap["season"]
+
+    lines.append(_hr("═"))
+    lines.append(f"  HERMITCRAFT SEASON {season} RECAP")
+    lines.append(_hr("═"))
+
+    # Dates + metadata
+    lines.append("")
+    start = recap.get("start_date") or "unknown"
+    end = recap.get("end_date") or "ongoing"
+    duration = recap.get("duration", "")
+    mc_ver = recap.get("minecraft_version", "")
+    count = recap.get("member_count", 0)
+    seed = recap.get("seed") or "not publicly known"
+    status = recap.get("status", "")
+
+    lines.append(f"  Start:    {start}")
+    lines.append(f"  End:      {end}" + (f"  ({duration})" if duration else ""))
+    lines.append(f"  MC:       {mc_ver}")
+    lines.append(f"  Members:  {count}")
+    lines.append(f"  Seed:     {seed}")
+    lines.append(f"  Status:   {status}")
+
+    theme = recap.get("theme", "")
+    if theme:
+        lines.append(f"  Theme:    {theme}")
+
+    # Overview
+    overview = recap.get("overview", "")
+    if overview:
+        lines.append("")
+        lines.append(_hr())
+        lines.append("OVERVIEW")
+        lines.append(_hr())
+        # Word-wrap to ~80 chars
+        words = overview.split()
+        row = ""
+        for w in words:
+            if len(row) + len(w) + 1 > 78:
+                lines.append("  " + row)
+                row = w
+            else:
+                row = (row + " " + w).strip()
+        if row:
+            lines.append("  " + row)
+
+    # Members
+    members = recap.get("members", [])
+    if members:
+        lines.append("")
+        lines.append(_hr())
+        lines.append(f"MEMBERS  ({len(members)})")
+        lines.append(_hr())
+        # Format in 3 columns
+        col_width = 22
+        for i in range(0, len(members), 3):
+            row_items = members[i:i + 3]
+            lines.append("  " + "".join(m.ljust(col_width) for m in row_items))
+
+    # Key themes
+    themes = recap.get("key_themes", [])
+    if themes:
+        lines.append("")
+        lines.append(_hr())
+        lines.append("KEY THEMES")
+        lines.append(_hr())
+        for t in themes:
+            lines.append(f"  • {t}")
+
+    # Notable events
+    events = recap.get("notable_events", [])
+    if events:
+        lines.append("")
+        lines.append(_hr())
+        lines.append("NOTABLE EVENTS")
+        lines.append(_hr())
+        for e in events:
+            lines.append(f"  • {e}")
+
+    # Major builds
+    builds = recap.get("major_builds", [])
+    if builds:
+        lines.append("")
+        lines.append(_hr())
+        lines.append("MAJOR BUILDS")
+        lines.append(_hr())
+        for b in builds:
+            lines.append(f"  • {b}")
+
+    # Timeline events from events.json
+    tl_events = recap.get("timeline_events", [])
+    if tl_events:
+        lines.append("")
+        lines.append(_hr())
+        lines.append(f"TIMELINE  ({len(tl_events)} events)")
+        lines.append(_hr())
+        for ev in tl_events:
+            date_str = ev.get("date", "")
+            title = ev.get("title", "")
+            lines.append(f"  {date_str:<12} {title}")
+
+    # Sources
+    sources = recap.get("sources", [])
+    if sources:
+        lines.append("")
+        lines.append(_hr())
+        lines.append("SOURCES")
+        lines.append(_hr())
+        for s in sources:
+            lines.append(f"  {s}")
+
+    lines.append("")
+    lines.append(_hr("═"))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="season_recap",
+        description="Rich digest for a given Hermitcraft season.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        help="Season number (1–11)",
+    )
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="List available seasons and exit",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Output a machine-readable JSON object instead of text",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        available = [s for s in KNOWN_SEASONS if (SEASONS_DIR / f"season-{s}.md").exists()]
+        if args.as_json:
+            print(json.dumps({"available_seasons": available}))
+        else:
+            print("Available seasons: " + ", ".join(str(s) for s in available))
+        return 0
+
+    season = args.season
+    if season not in KNOWN_SEASONS:
+        sys.stderr.write(f"[season_recap] unknown season: {season}. "
+                         f"Valid range: {KNOWN_SEASONS[0]}–{KNOWN_SEASONS[-1]}\n")
+        return 2
+
+    try:
+        recap = build_recap(season)
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"[season_recap] {exc}\n")
+        return 1
+
+    if args.as_json:
+        print(json.dumps(recap, indent=2, ensure_ascii=False))
+    else:
+        print(format_text(recap))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Introduces `tools/season_recap.py` — a CLI tool that outputs a rich structured digest for any Hermitcraft season (1–11)
- **Text mode** (`--season N`): formatted header, dates, members table, key themes, notable events, major builds, and timeline events from `events.json`
- **JSON mode** (`--season N --json`): machine-readable object for downstream tools and prompts
- **List mode** (`--list`): enumerate all available seasons; also supports `--list --json`
- Parses `knowledge/seasons/season-N.md` (YAML frontmatter + markdown sections) and filters `knowledge/timelines/events.json` by season
- Handles edge cases: lowercase hermit handles (iJevin, xBCrafted), bold/italic member notation, prose lines vs actual roster lines

## Example output

```
$ python3 tools/season_recap.py --season 7
════════════════════════════════════════════════════════════
  HERMITCRAFT SEASON 7 RECAP
════════════════════════════════════════════════════════════
  Start:    2020-02-28
  End:      2021-06-12  (~15.5 months)
  MC:       1.15.2–1.16.x
  Members:  24  ...
TIMELINE  (7 events)
  2020-02-28   Season 7 Launch
  2020-06-23   1.16 Nether Update — Nether Reset
  ...
```

## Tests

66 tests in `tests/test_season_recap.py` covering:
- All 5 helper functions (frontmatter, section, bullet, member, paragraph parsers)
- `load_season_file` and `load_events_for_season` with real data
- `build_recap` — 16 assertions including seasons 7, 8, 9
- `format_text` — 8 assertions
- CLI — 11 end-to-end subprocess tests (text, JSON, --list, error codes)
- Constants — 5 sanity checks

All 66 pass.

## Test plan

- [ ] `python3 tools/season_recap.py --season 7` prints a readable digest
- [ ] `python3 tools/season_recap.py --season 9 --json` outputs valid JSON with `members`, `timeline_events`, etc.
- [ ] `python3 tools/season_recap.py --season 99` exits 2 with error message
- [ ] `python3 tools/season_recap.py --list` shows seasons 1–11
- [ ] All 66 tests pass

Closes #73