### PR TITLE
[hermitcraft-agent] Add --month and --timeline-only flags to season_recap for chronological browsing

### DIFF
--- a/tests/test_season_recap.py
+++ b/tests/test_season_recap.py
@@ -18,8 +18,11 @@ from tools.season_recap import (
     _extract_bullet_list,
     _extract_members_from_text,
     _extract_first_paragraph,
+    _event_sort_key,
     build_recap,
     format_text,
+    format_timeline_text,
+    filter_timeline_by_month,
     load_season_file,
     load_events_for_season,
     SEASONS_DIR,
@@ -408,6 +411,224 @@ class TestCLI(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Unit tests — _event_sort_key
+# ---------------------------------------------------------------------------
+
+class TestEventSortKey(unittest.TestCase):
+    def test_full_date_sorts_correctly(self):
+        a = {'date': '2020-02-28', 'date_precision': 'day'}
+        b = {'date': '2020-06-23', 'date_precision': 'day'}
+        self.assertLess(_event_sort_key(a), _event_sort_key(b))
+
+    def test_year_only_sorts_before_month(self):
+        year_event = {'date': '2020', 'date_precision': 'year'}
+        month_event = {'date': '2020-03', 'date_precision': 'month'}
+        # year-only → (2020, 0, 0); month-only → (2020, 3, 0)
+        self.assertLess(_event_sort_key(year_event), _event_sort_key(month_event))
+
+    def test_missing_date_returns_zeros(self):
+        key = _event_sort_key({'date': ''})
+        self.assertEqual(key, (0, 0, 0))
+
+    def test_events_sorted_chronologically(self):
+        events = [
+            {'date': '2022-12-20', 'season': 9},
+            {'date': '2022-03-05', 'season': 9},
+            {'date': '2022-07-02', 'season': 9},
+        ]
+        sorted_events = sorted(events, key=_event_sort_key)
+        dates = [e['date'] for e in sorted_events]
+        self.assertEqual(dates, ['2022-03-05', '2022-07-02', '2022-12-20'])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — filter_timeline_by_month
+# ---------------------------------------------------------------------------
+
+class TestFilterTimelineByMonth(unittest.TestCase):
+    EVENTS = [
+        {'id': 'a', 'date': '2022-03-05', 'date_precision': 'day',   'season': 9},
+        {'id': 'b', 'date': '2022-07-02', 'date_precision': 'day',   'season': 9},
+        {'id': 'c', 'date': '2022',       'date_precision': 'year',  'season': 9},
+        {'id': 'd', 'date': '2022-03-15', 'date_precision': 'day',   'season': 9},
+        {'id': 'e', 'date': '2023-12-20', 'date_precision': 'day',   'season': 9},
+    ]
+
+    def test_filter_march_returns_march_events(self):
+        result = filter_timeline_by_month(self.EVENTS, 3)
+        ids = [e['id'] for e in result]
+        self.assertIn('a', ids)
+        self.assertIn('d', ids)
+        self.assertNotIn('b', ids)
+        self.assertNotIn('e', ids)
+
+    def test_year_only_events_excluded_from_month_filter(self):
+        result = filter_timeline_by_month(self.EVENTS, 3)
+        ids = [e['id'] for e in result]
+        self.assertNotIn('c', ids)
+
+    def test_month_with_no_matches_returns_empty(self):
+        result = filter_timeline_by_month(self.EVENTS, 4)
+        self.assertEqual(result, [])
+
+    def test_empty_events_returns_empty(self):
+        self.assertEqual(filter_timeline_by_month([], 6), [])
+
+    def test_december_filter(self):
+        result = filter_timeline_by_month(self.EVENTS, 12)
+        ids = [e['id'] for e in result]
+        self.assertIn('e', ids)
+        self.assertEqual(len(result), 1)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — load_events_for_season chronological order
+# ---------------------------------------------------------------------------
+
+class TestLoadEventsChronological(unittest.TestCase):
+    def test_season_7_events_sorted(self):
+        events = load_events_for_season(7)
+        keys = [_event_sort_key(e) for e in events]
+        self.assertEqual(keys, sorted(keys),
+                         "Season 7 events are not in chronological order")
+
+    def test_season_9_events_sorted(self):
+        events = load_events_for_season(9)
+        keys = [_event_sort_key(e) for e in events]
+        self.assertEqual(keys, sorted(keys),
+                         "Season 9 events are not in chronological order")
+
+    def test_all_seasons_chronological(self):
+        for s in range(1, 12):
+            events = load_events_for_season(s)
+            keys = [_event_sort_key(e) for e in events]
+            self.assertEqual(keys, sorted(keys),
+                             f"Season {s} events are not in chronological order")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — format_timeline_text
+# ---------------------------------------------------------------------------
+
+class TestFormatTimelineText(unittest.TestCase):
+    def setUp(self):
+        self.events7 = load_events_for_season(7)
+        self.events9 = load_events_for_season(9)
+
+    def test_returns_string(self):
+        self.assertIsInstance(format_timeline_text(7, self.events7), str)
+
+    def test_header_contains_season(self):
+        out = format_timeline_text(7, self.events7)
+        self.assertIn('SEASON 7 TIMELINE', out)
+
+    def test_month_label_in_header(self):
+        out = format_timeline_text(9, self.events9, month=3)
+        self.assertIn('March', out)
+
+    def test_event_titles_present(self):
+        out = format_timeline_text(7, self.events7)
+        self.assertIn('Season 7', out)
+
+    def test_hermit_names_present(self):
+        out = format_timeline_text(7, self.events7)
+        # At least one event references "All" or a hermit name
+        self.assertTrue('All' in out or 'TangoTek' in out or 'Grian' in out)
+
+    def test_empty_events_shows_no_events_message(self):
+        out = format_timeline_text(9, [], month=4)
+        self.assertIn('No events found', out)
+
+    def test_approximate_date_prefixed_with_tilde(self):
+        approx_event = [{
+            'id': 't1', 'date': '2020-11', 'date_precision': 'approximate',
+            'season': 7, 'hermits': ['Grian'], 'title': 'Test Event',
+            'description': 'A test.', 'type': 'lore',
+        }]
+        out = format_timeline_text(7, approx_event)
+        self.assertIn('~2020-11', out)
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — timeline-only and month flags
+# ---------------------------------------------------------------------------
+
+class TestCLITimeline(unittest.TestCase):
+    def _run(self, *args: str) -> tuple[int, str, str]:
+        result = subprocess.run(
+            [sys.executable, SCRIPT, *args],
+            capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def test_timeline_only_exits_0(self):
+        rc, _, _ = self._run('--season', '7', '--timeline-only')
+        self.assertEqual(rc, 0)
+
+    def test_timeline_only_contains_timeline_header(self):
+        _, stdout, _ = self._run('--season', '7', '--timeline-only')
+        self.assertIn('SEASON 7 TIMELINE', stdout)
+
+    def test_timeline_only_json_valid(self):
+        rc, stdout, _ = self._run('--season', '9', '--timeline-only', '--json')
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertEqual(data['season'], 9)
+        self.assertIn('events', data)
+        self.assertIn('event_count', data)
+
+    def test_timeline_only_json_events_sorted(self):
+        _, stdout, _ = self._run('--season', '9', '--timeline-only', '--json')
+        data = json.loads(stdout)
+        events = data['events']
+        keys = [_event_sort_key(e) for e in events]
+        self.assertEqual(keys, sorted(keys), "Events not sorted chronologically")
+
+    def test_month_implies_timeline_only(self):
+        # --month without --timeline-only should still work (--month implies it)
+        rc, stdout, _ = self._run('--season', '9', '--month', '3')
+        self.assertEqual(rc, 0)
+        self.assertIn('TIMELINE', stdout)
+        self.assertIn('March', stdout)
+
+    def test_month_filter_json(self):
+        rc, stdout, _ = self._run('--season', '7', '--month', '6', '--json')
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertEqual(data['month'], 6)
+        for ev in data['events']:
+            # Every returned event must be in June
+            self.assertTrue(ev['date'].startswith('2') and '-06-' in ev['date']
+                            or ev['date'].endswith('-06'),
+                            f"Event {ev['date']} not in June")
+
+    def test_month_out_of_range_exits_2(self):
+        rc, _, stderr = self._run('--season', '9', '--month', '13')
+        self.assertEqual(rc, 2)
+        self.assertIn('invalid month', stderr)
+
+    def test_month_with_no_events_exits_0(self):
+        # April (month 4) has no events in S9 — should exit 0, not error
+        rc, stdout, _ = self._run('--season', '9', '--month', '4')
+        self.assertEqual(rc, 0)
+        self.assertIn('No events found', stdout)
+
+    def test_timeline_json_each_event_has_required_fields(self):
+        _, stdout, _ = self._run('--season', '7', '--timeline-only', '--json')
+        data = json.loads(stdout)
+        for ev in data['events']:
+            for field in ('id', 'date', 'season', 'hermits', 'title', 'description'):
+                self.assertIn(field, ev, f"Event missing field '{field}': {ev}")
+
+    def test_seasons_7_8_9_timeline_all_have_events(self):
+        for s in [7, 8, 9]:
+            rc, stdout, _ = self._run('--season', str(s), '--timeline-only', '--json')
+            self.assertEqual(rc, 0)
+            data = json.loads(stdout)
+            self.assertGreater(data['event_count'], 0, f"Season {s} has no events")
+
+
+# ---------------------------------------------------------------------------
 # KNOWN_SEASONS constant
 # ---------------------------------------------------------------------------
 
@@ -440,11 +661,16 @@ if __name__ == '__main__':
         ('_extract_bullet_list', unittest.TestLoader().loadTestsFromTestCase(TestExtractBulletList)),
         ('_extract_members_from_text', unittest.TestLoader().loadTestsFromTestCase(TestExtractMembersFromText)),
         ('_extract_first_paragraph', unittest.TestLoader().loadTestsFromTestCase(TestExtractFirstParagraph)),
+        ('_event_sort_key', unittest.TestLoader().loadTestsFromTestCase(TestEventSortKey)),
+        ('filter_timeline_by_month', unittest.TestLoader().loadTestsFromTestCase(TestFilterTimelineByMonth)),
         ('load_season_file', unittest.TestLoader().loadTestsFromTestCase(TestLoadSeasonFile)),
         ('load_events_for_season', unittest.TestLoader().loadTestsFromTestCase(TestLoadEventsForSeason)),
+        ('load_events_chronological', unittest.TestLoader().loadTestsFromTestCase(TestLoadEventsChronological)),
         ('build_recap', unittest.TestLoader().loadTestsFromTestCase(TestBuildRecap)),
         ('format_text', unittest.TestLoader().loadTestsFromTestCase(TestFormatText)),
+        ('format_timeline_text', unittest.TestLoader().loadTestsFromTestCase(TestFormatTimelineText)),
         ('CLI', unittest.TestLoader().loadTestsFromTestCase(TestCLI)),
+        ('CLI_timeline', unittest.TestLoader().loadTestsFromTestCase(TestCLITimeline)),
         ('constants', unittest.TestLoader().loadTestsFromTestCase(TestConstants)),
     ]
 

--- a/tools/season_recap.py
+++ b/tools/season_recap.py
@@ -7,14 +7,23 @@ the season markdown file and the shared events timeline.
 
 Usage
 -----
-  python3 tools/season_recap.py --season 9          # formatted text
-  python3 tools/season_recap.py --season 7 --json   # machine-readable JSON
-  python3 tools/season_recap.py --list               # list available seasons
+  python3 tools/season_recap.py --season 9              # full text digest
+  python3 tools/season_recap.py --season 7 --json       # machine-readable JSON
+  python3 tools/season_recap.py --list                  # list available seasons
+  python3 tools/season_recap.py --season 9 --month 3   # S9 events in March
+  python3 tools/season_recap.py --season 7 --timeline-only          # events only
+  python3 tools/season_recap.py --season 9 --month 6 --timeline-only --json
 
 Output (text mode)
 ------------------
   Season header, dates, members, key themes, notable events, major builds,
   and timeline events sourced from knowledge/timelines/events.json.
+
+Output (--timeline-only mode)
+------------------------------
+  Chronologically sorted events for the season (optionally filtered by
+  --month N). Each entry shows: date, hermit(s), title, and description.
+  Suitable for answering "what was happening in Season 9 in Month 3?".
 
 Output (JSON mode)
 ------------------
@@ -185,10 +194,24 @@ def load_season_file(season: int) -> tuple[dict, dict[str, str]]:
     return frontmatter, sections
 
 
+def _event_sort_key(event: dict) -> tuple:
+    """
+    Return a (year, month, day) tuple suitable for chronological sorting.
+    Missing date parts are replaced with 0 so partial dates sort first
+    within their group.
+    """
+    raw: str = event.get("date", "")
+    parts = raw.split("-")
+    year  = int(parts[0]) if len(parts) >= 1 and parts[0].isdigit() else 0
+    month = int(parts[1]) if len(parts) >= 2 and parts[1].isdigit() else 0
+    day   = int(parts[2]) if len(parts) >= 3 and parts[2].isdigit() else 0
+    return (year, month, day)
+
+
 def load_events_for_season(season: int) -> list[dict]:
     """
     Load ``knowledge/timelines/events.json`` and return only events
-    whose ``season`` field equals *season*.
+    whose ``season`` field equals *season*, sorted chronologically.
     """
     if not EVENTS_FILE.exists():
         return []
@@ -197,7 +220,27 @@ def load_events_for_season(season: int) -> list[dict]:
             all_events: list[dict] = json.load(fh)
     except (json.JSONDecodeError, OSError):
         return []
-    return [e for e in all_events if e.get("season") == season]
+    season_events = [e for e in all_events if e.get("season") == season]
+    return sorted(season_events, key=_event_sort_key)
+
+
+def filter_timeline_by_month(events: list[dict], month: int) -> list[dict]:
+    """
+    Return only those *events* whose date falls in *month* (1–12).
+
+    Events with year-only precision (``date_precision == "year"`` or dates
+    without a month component) are excluded when filtering by month, since
+    their month is genuinely unknown.
+    """
+    filtered = []
+    for ev in events:
+        raw = ev.get("date", "")
+        parts = raw.split("-")
+        if len(parts) < 2 or not parts[1].isdigit():
+            continue  # year-only — cannot match a specific month
+        if int(parts[1]) == month:
+            filtered.append(ev)
+    return filtered
 
 
 # ---------------------------------------------------------------------------
@@ -390,6 +433,80 @@ def format_text(recap: dict) -> str:
     return "\n".join(lines)
 
 
+_MONTH_NAMES = [
+    "", "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]
+
+
+def format_timeline_text(
+    season: int,
+    events: list[dict],
+    month: int | None = None,
+) -> str:
+    """
+    Return a human-readable chronological timeline for *season*.
+
+    Each event line shows: date, hermit(s), title.
+    A description block follows each entry.
+    *month*, if given, is used only in the header label.
+    """
+    lines: list[str] = []
+
+    month_label = f" — {_MONTH_NAMES[month]}" if month and 1 <= month <= 12 else ""
+    lines.append(_hr("═"))
+    lines.append(f"  HERMITCRAFT SEASON {season} TIMELINE{month_label}")
+    lines.append(_hr("═"))
+
+    if not events:
+        lines.append("")
+        lines.append("  No events found for this query.")
+        lines.append("")
+        lines.append(_hr("═"))
+        return "\n".join(lines)
+
+    for ev in events:
+        date_str = ev.get("date", "unknown date")
+        precision = ev.get("date_precision", "day")
+        title = ev.get("title", "")
+        hermits = ev.get("hermits", [])
+        description = ev.get("description", "")
+
+        # Date label with precision hint
+        if precision == "approximate":
+            date_label = f"~{date_str}"
+        elif precision in ("month", "year"):
+            date_label = date_str
+        else:
+            date_label = date_str
+
+        # Hermit list
+        hermit_str = ", ".join(hermits) if hermits else "unknown"
+
+        lines.append("")
+        lines.append(f"  {date_label}  [{hermit_str}]")
+        lines.append(f"  {title}")
+
+        # Word-wrap description at ~76 chars
+        if description:
+            words = description.split()
+            row = ""
+            for w in words:
+                if len(row) + len(w) + 1 > 74:
+                    lines.append("    " + row)
+                    row = w
+                else:
+                    row = (row + " " + w).strip()
+            if row:
+                lines.append("    " + row)
+
+        lines.append("  " + "·" * 56)
+
+    lines.append("")
+    lines.append(_hr("═"))
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -397,7 +514,11 @@ def format_text(recap: dict) -> str:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="season_recap",
-        description="Rich digest for a given Hermitcraft season.",
+        description=(
+            "Rich digest for a given Hermitcraft season. "
+            "Use --timeline-only for chronological event browsing, "
+            "optionally filtered by --month."
+        ),
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -412,10 +533,23 @@ def _build_parser() -> argparse.ArgumentParser:
         help="List available seasons and exit",
     )
     parser.add_argument(
+        "--month",
+        type=int,
+        metavar="M",
+        help="Filter timeline events to a specific month (1–12); "
+             "implies --timeline-only",
+    )
+    parser.add_argument(
+        "--timeline-only",
+        action="store_true",
+        dest="timeline_only",
+        help="Output only the chronological event timeline (no full recap)",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         dest="as_json",
-        help="Output a machine-readable JSON object instead of text",
+        help="Output machine-readable JSON instead of text",
     )
     return parser
 
@@ -423,6 +557,10 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    # --month implies --timeline-only
+    if args.month is not None:
+        args.timeline_only = True
 
     if args.list:
         available = [s for s in KNOWN_SEASONS if (SEASONS_DIR / f"season-{s}.md").exists()]
@@ -438,6 +576,31 @@ def main(argv: list[str] | None = None) -> int:
                          f"Valid range: {KNOWN_SEASONS[0]}–{KNOWN_SEASONS[-1]}\n")
         return 2
 
+    # Validate --month range
+    if args.month is not None and not (1 <= args.month <= 12):
+        sys.stderr.write(f"[season_recap] invalid month: {args.month}. "
+                         "Must be 1–12.\n")
+        return 2
+
+    if args.timeline_only:
+        # Timeline-only path: no need to load the season markdown
+        events = load_events_for_season(season)
+        if args.month is not None:
+            events = filter_timeline_by_month(events, args.month)
+
+        if args.as_json:
+            payload = {
+                "season": season,
+                "month": args.month,
+                "event_count": len(events),
+                "events": events,
+            }
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+        else:
+            print(format_timeline_text(season, events, month=args.month))
+        return 0
+
+    # Full recap path
     try:
         recap = build_recap(season)
     except FileNotFoundError as exc:


### PR DESCRIPTION
## Summary

Extends `tools/season_recap.py` with chronological timeline browsing, directly addressing issue #75's requirement: *"what was happening in Hermitcraft in Season 9, Month 3?"*

- **`--timeline-only`**: emits just the event list (date, hermit(s), title, description) without the full season digest
- **`--month N`**: filters timeline to a specific calendar month (1–12); implies `--timeline-only` automatically
- Both flags work with `--json` for machine-readable output; JSON payload includes `season`, `month`, `event_count`, `events[]`
- `load_events_for_season` now returns events sorted **chronologically** (was unordered)
- New helpers: `_event_sort_key`, `filter_timeline_by_month`, `format_timeline_text`

## Example queries

```sh
# What was happening in Season 9 in March?
python3 tools/season_recap.py --season 9 --month 3

# Full chronological event log for Season 7
python3 tools/season_recap.py --season 7 --timeline-only

# Machine-readable — Season 7, June events
python3 tools/season_recap.py --season 7 --month 6 --json
```

## Output sample

```
════════════════════════════════════════════════════════════
  HERMITCRAFT SEASON 9 TIMELINE — March
════════════════════════════════════════════════════════════

  2022-03-05  [All]
  Season 9 Launch
    Hermitcraft Season 9 launches on Minecraft 1.18.1 using the Fabric
    mod loader, with zero roster changes from Season 8.
  ························································
```

## Acceptance criteria (from #75)

- [x] Covers S7–S9 — each of these seasons has events in the timeline
- [x] Each event entry has hermits, description, and approximate date
- [x] Response is sorted chronologically
- [x] `--month` filter works for targeted queries

## Tests

29 new tests added (95 total, all passing):
- `TestEventSortKey` (4) — sort key logic
- `TestFilterTimelineByMonth` (5) — month filtering incl. year-only exclusion
- `TestLoadEventsChronological` (3) — validates all 11 seasons sort correctly
- `TestFormatTimelineText` (7) — output format, month label, empty case, `~` prefix
- `TestCLITimeline` (10) — end-to-end CLI: text, JSON, `--month`, error codes, field presence

## Test plan

- [ ] `python3 tools/season_recap.py --season 9 --month 3` shows the S9 launch event
- [ ] `python3 tools/season_recap.py --season 7 --timeline-only --json` returns sorted events
- [ ] `python3 tools/season_recap.py --season 9 --month 13` exits 2 with error
- [ ] All 95 tests pass

Closes #75