### PR TITLE
[hermitcraft-agent] Add --hermit filter to season_recap and on_this_day

### DIFF
--- a/tests/test_on_this_day.py
+++ b/tests/test_on_this_day.py
@@ -18,6 +18,7 @@ from tools.on_this_day import (
     VIDEO_EVENTS_FILE,
     _infer_precision,
     _parse_frontmatter,
+    filter_by_hermit,
     find_on_this_day,
     load_events,
     load_hermit_profiles,
@@ -902,6 +903,147 @@ class TestVideoEventsCLI(unittest.TestCase):
             all_count = len(all_result.stdout.strip().splitlines())
             vid_count = len(vid_result.stdout.strip().splitlines())
             self.assertGreaterEqual(all_count, vid_count)
+
+
+# ---------------------------------------------------------------------------
+# TestFilterByHermit
+# ---------------------------------------------------------------------------
+
+class TestFilterByHermit(unittest.TestCase):
+    """Tests for filter_by_hermit()."""
+
+    EVENTS = [
+        _make_event(id="all-1",   hermits=["All"],             title="Server-wide event"),
+        _make_event(id="grian-1", hermits=["Grian"],           title="Grian solo event"),
+        _make_event(id="duo-1",   hermits=["Grian", "MumboJumbo"], title="Duo event"),
+        _make_event(id="tango-1", hermits=["TangoTek"],        title="TangoTek event"),
+        _make_event(id="empty-1", hermits=[],                  title="Unknown participants"),
+    ]
+
+    def test_all_event_always_included(self):
+        results = filter_by_hermit(self.EVENTS, "Grian")
+        ids = [e["id"] for e in results]
+        self.assertIn("all-1", ids)
+
+    def test_matching_hermit_included(self):
+        results = filter_by_hermit(self.EVENTS, "Grian")
+        ids = [e["id"] for e in results]
+        self.assertIn("grian-1", ids)
+
+    def test_multi_hermit_event_included(self):
+        results = filter_by_hermit(self.EVENTS, "Grian")
+        ids = [e["id"] for e in results]
+        self.assertIn("duo-1", ids)
+
+    def test_non_matching_hermit_excluded(self):
+        results = filter_by_hermit(self.EVENTS, "Grian")
+        ids = [e["id"] for e in results]
+        self.assertNotIn("tango-1", ids)
+
+    def test_empty_hermit_list_excluded(self):
+        results = filter_by_hermit(self.EVENTS, "Grian")
+        ids = [e["id"] for e in results]
+        self.assertNotIn("empty-1", ids)
+
+    def test_case_insensitive_match(self):
+        results_lower = filter_by_hermit(self.EVENTS, "grian")
+        results_upper = filter_by_hermit(self.EVENTS, "GRIAN")
+        results_mixed = filter_by_hermit(self.EVENTS, "Grian")
+        self.assertEqual([e["id"] for e in results_lower],
+                         [e["id"] for e in results_mixed])
+        self.assertEqual([e["id"] for e in results_upper],
+                         [e["id"] for e in results_mixed])
+
+    def test_no_match_returns_only_all_events(self):
+        results = filter_by_hermit(self.EVENTS, "ZombieCleo")
+        ids = [e["id"] for e in results]
+        self.assertEqual(ids, ["all-1"])
+
+    def test_empty_event_list(self):
+        self.assertEqual(filter_by_hermit([], "Grian"), [])
+
+    def test_tangotek_filter(self):
+        results = filter_by_hermit(self.EVENTS, "TangoTek")
+        ids = [e["id"] for e in results]
+        self.assertIn("tango-1", ids)
+        self.assertIn("all-1", ids)
+        self.assertNotIn("grian-1", ids)
+
+
+class TestFilterByHermitCLI(unittest.TestCase):
+    """CLI tests for the --hermit flag in on_this_day."""
+
+    SCRIPT = str(ROOT / "tools" / "on_this_day.py")
+
+    def _run(self, *args: str):
+        return subprocess.run(
+            [sys.executable, self.SCRIPT, *args],
+            capture_output=True, text=True,
+        )
+
+    def test_hermit_flag_exits_0_when_events_found(self):
+        # April 13 has server-wide "All" events that always match any hermit
+        result = self._run(
+            "--month", "4", "--day", "13",
+            "--include-year", "--hermit", "Generikb",
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_hermit_filter_output_only_relevant_events(self):
+        result = self._run(
+            "--month", "4", "--day", "13",
+            "--all-events", "--hermit", "Generikb", "--pretty",
+        )
+        self.assertEqual(result.returncode, 0)
+        events = json.loads(result.stdout)
+        for ev in events:
+            hermits = ev.get("hermits", [])
+            self.assertTrue(
+                hermits == ["All"]
+                or any(h.lower() == "generikb" for h in hermits),
+                f"Event includes unexpected hermit list: {hermits}",
+            )
+
+    def test_hermit_case_insensitive_cli(self):
+        result_lower = self._run(
+            "--month", "4", "--day", "13",
+            "--all-events", "--hermit", "generikb", "--pretty",
+        )
+        result_proper = self._run(
+            "--month", "4", "--day", "13",
+            "--all-events", "--hermit", "Generikb", "--pretty",
+        )
+        if result_lower.returncode == 0 and result_proper.returncode == 0:
+            self.assertEqual(
+                json.loads(result_lower.stdout),
+                json.loads(result_proper.stdout),
+            )
+
+    def test_hermit_filter_only_returns_relevant_events(self):
+        # Every returned event must either be ["All"] or mention the hermit
+        result = self._run(
+            "--month", "4", "--day", "13",
+            "--include-year", "--hermit", "ZombieCleo", "--pretty",
+        )
+        if result.returncode == 0:
+            events = json.loads(result.stdout)
+            for ev in events:
+                hermits = ev.get("hermits", [])
+                self.assertTrue(
+                    hermits == ["All"]
+                    or any(h.lower() == "zombiecleo" for h in hermits),
+                    f"Unexpected hermit list for ZombieCleo filter: {hermits}",
+                )
+
+    def test_hermit_flag_does_not_affect_ndjson_format(self):
+        result = self._run(
+            "--month", "4", "--day", "13",
+            "--include-year", "--hermit", "Generikb",
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                obj = json.loads(line)
+                self.assertIn("id", obj)
 
 
 if __name__ == "__main__":

--- a/tests/test_season_recap.py
+++ b/tests/test_season_recap.py
@@ -20,9 +20,10 @@ from tools.season_recap import (
     _extract_first_paragraph,
     _event_sort_key,
     build_recap,
+    filter_by_hermit,
+    filter_timeline_by_month,
     format_text,
     format_timeline_text,
-    filter_timeline_by_month,
     load_season_file,
     load_events_for_season,
     SEASONS_DIR,
@@ -629,6 +630,134 @@ class TestCLITimeline(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Unit tests — filter_by_hermit
+# ---------------------------------------------------------------------------
+
+class TestFilterByHermit(unittest.TestCase):
+    EVENTS = [
+        {'id': 'all-1',   'hermits': ['All'],                 'title': 'Server-wide'},
+        {'id': 'grian-1', 'hermits': ['Grian'],               'title': 'Grian solo'},
+        {'id': 'duo-1',   'hermits': ['Grian', 'MumboJumbo'], 'title': 'Duo event'},
+        {'id': 'tango-1', 'hermits': ['TangoTek'],            'title': 'TangoTek solo'},
+        {'id': 'empty-1', 'hermits': [],                      'title': 'Unknown'},
+    ]
+
+    def test_all_event_always_included(self):
+        ids = [e['id'] for e in filter_by_hermit(self.EVENTS, 'Grian')]
+        self.assertIn('all-1', ids)
+
+    def test_named_hermit_included(self):
+        ids = [e['id'] for e in filter_by_hermit(self.EVENTS, 'Grian')]
+        self.assertIn('grian-1', ids)
+
+    def test_multi_hermit_event_included(self):
+        ids = [e['id'] for e in filter_by_hermit(self.EVENTS, 'Grian')]
+        self.assertIn('duo-1', ids)
+
+    def test_non_matching_hermit_excluded(self):
+        ids = [e['id'] for e in filter_by_hermit(self.EVENTS, 'Grian')]
+        self.assertNotIn('tango-1', ids)
+
+    def test_empty_hermit_list_excluded(self):
+        ids = [e['id'] for e in filter_by_hermit(self.EVENTS, 'Grian')]
+        self.assertNotIn('empty-1', ids)
+
+    def test_case_insensitive_lowercase(self):
+        lower = filter_by_hermit(self.EVENTS, 'grian')
+        proper = filter_by_hermit(self.EVENTS, 'Grian')
+        self.assertEqual([e['id'] for e in lower], [e['id'] for e in proper])
+
+    def test_case_insensitive_uppercase(self):
+        upper = filter_by_hermit(self.EVENTS, 'GRIAN')
+        proper = filter_by_hermit(self.EVENTS, 'Grian')
+        self.assertEqual([e['id'] for e in upper], [e['id'] for e in proper])
+
+    def test_unknown_hermit_returns_only_all_events(self):
+        results = filter_by_hermit(self.EVENTS, 'ZombieCleo')
+        ids = [e['id'] for e in results]
+        self.assertEqual(ids, ['all-1'])
+
+    def test_empty_event_list_returns_empty(self):
+        self.assertEqual(filter_by_hermit([], 'Grian'), [])
+
+    def test_tangotek_gets_solo_and_all(self):
+        ids = [e['id'] for e in filter_by_hermit(self.EVENTS, 'TangoTek')]
+        self.assertIn('tango-1', ids)
+        self.assertIn('all-1', ids)
+        self.assertNotIn('grian-1', ids)
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — --hermit flag in season_recap
+# ---------------------------------------------------------------------------
+
+class TestCLIHermit(unittest.TestCase):
+    def _run(self, *args: str) -> tuple[int, str, str]:
+        result = subprocess.run(
+            [sys.executable, SCRIPT, *args],
+            capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def test_hermit_flag_exits_0(self):
+        rc, _, _ = self._run('--season', '7', '--hermit', 'TangoTek')
+        self.assertEqual(rc, 0)
+
+    def test_hermit_implies_timeline_only(self):
+        _, stdout, _ = self._run('--season', '7', '--hermit', 'Grian')
+        # Should produce timeline output, not full recap
+        self.assertIn('TIMELINE', stdout)
+        self.assertNotIn('MEMBERS', stdout)
+
+    def test_hermit_label_in_header(self):
+        _, stdout, _ = self._run('--season', '7', '--hermit', 'TangoTek')
+        self.assertIn('TangoTek', stdout)
+
+    def test_hermit_json_contains_hermit_field(self):
+        rc, stdout, _ = self._run('--season', '7', '--hermit', 'Grian', '--json')
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertEqual(data['hermit'], 'Grian')
+
+    def test_hermit_json_events_all_relevant(self):
+        _, stdout, _ = self._run('--season', '7', '--hermit', 'TangoTek', '--json')
+        data = json.loads(stdout)
+        for ev in data['events']:
+            hermits = ev.get('hermits', [])
+            self.assertTrue(
+                hermits == ['All']
+                or any(h.lower() == 'tangotek' for h in hermits),
+                f"Event has unexpected hermits: {hermits}",
+            )
+
+    def test_hermit_case_insensitive(self):
+        _, out_lower, _ = self._run('--season', '7', '--hermit', 'grian', '--json')
+        _, out_proper, _ = self._run('--season', '7', '--hermit', 'Grian', '--json')
+        data_lower = json.loads(out_lower)
+        data_proper = json.loads(out_proper)
+        self.assertEqual(data_lower['event_count'], data_proper['event_count'])
+
+    def test_hermit_combined_with_month(self):
+        rc, stdout, _ = self._run(
+            '--season', '7', '--hermit', 'TangoTek', '--month', '6', '--json'
+        )
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertEqual(data['hermit'], 'TangoTek')
+        self.assertEqual(data['month'], 6)
+
+    def test_hermit_decked_out_tangotek_season7(self):
+        _, stdout, _ = self._run('--season', '7', '--hermit', 'TangoTek', '--json')
+        data = json.loads(stdout)
+        titles = [ev['title'] for ev in data['events']]
+        # Decked Out event specifically involves TangoTek
+        self.assertTrue(
+            any('Decked Out' in t or 'TangoTek' in t for t in titles),
+            f"Expected Decked Out event, got: {titles}",
+        )
+
+
+# ---------------------------------------------------------------------------
 # KNOWN_SEASONS constant
 # ---------------------------------------------------------------------------
 
@@ -671,6 +800,8 @@ if __name__ == '__main__':
         ('format_timeline_text', unittest.TestLoader().loadTestsFromTestCase(TestFormatTimelineText)),
         ('CLI', unittest.TestLoader().loadTestsFromTestCase(TestCLI)),
         ('CLI_timeline', unittest.TestLoader().loadTestsFromTestCase(TestCLITimeline)),
+        ('filter_by_hermit', unittest.TestLoader().loadTestsFromTestCase(TestFilterByHermit)),
+        ('CLI_hermit', unittest.TestLoader().loadTestsFromTestCase(TestCLIHermit)),
         ('constants', unittest.TestLoader().loadTestsFromTestCase(TestConstants)),
     ]
 

--- a/tools/on_this_day.py
+++ b/tools/on_this_day.py
@@ -353,6 +353,28 @@ def synthesise_hermit_events(profiles: list[dict]) -> list[dict]:
     return events
 
 
+def filter_by_hermit(events: list[dict], hermit_name: str) -> list[dict]:
+    """
+    Return only those *events* that involve *hermit_name*.
+
+    An event matches when:
+    * ``event["hermits"]`` equals ``["All"]`` (server-wide events), OR
+    * *hermit_name* appears in ``event["hermits"]`` (case-insensitive).
+
+    An empty hermit list does **not** match, since the event's participants
+    are genuinely unknown.
+    """
+    name_lower = hermit_name.lower()
+    result = []
+    for ev in events:
+        hermits: list = ev.get("hermits", [])
+        if hermits == ["All"]:
+            result.append(ev)
+        elif any(h.lower() == name_lower for h in hermits):
+            result.append(ev)
+    return result
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="On This Day in Hermitcraft — historical event digest",
@@ -404,6 +426,13 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--hermit", metavar="NAME", default=None,
+        help=(
+            "Filter results to events involving a specific hermit (case-insensitive). "
+            "Server-wide events (hermits=[All]) are always included."
+        ),
+    )
+    parser.add_argument(
         "--pretty", action="store_true",
         help="Output a pretty-printed JSON array instead of NDJSON.",
     )
@@ -447,6 +476,9 @@ def main(argv: list[str] | None = None) -> int:
         include_approximate=args.include_approximate,
         include_year=args.include_year,
     )
+
+    if args.hermit is not None:
+        results = filter_by_hermit(results, args.hermit)
 
     if not results:
         sys.stderr.write(

--- a/tools/season_recap.py
+++ b/tools/season_recap.py
@@ -243,6 +243,28 @@ def filter_timeline_by_month(events: list[dict], month: int) -> list[dict]:
     return filtered
 
 
+def filter_by_hermit(events: list[dict], hermit_name: str) -> list[dict]:
+    """
+    Return only those *events* that involve *hermit_name*.
+
+    An event matches when:
+    * ``event["hermits"]`` equals ``["All"]`` (server-wide events), OR
+    * *hermit_name* appears in ``event["hermits"]`` (case-insensitive).
+
+    An empty hermit list does **not** match, since the event's participants
+    are genuinely unknown.
+    """
+    name_lower = hermit_name.lower()
+    result = []
+    for ev in events:
+        hermits: list = ev.get("hermits", [])
+        if hermits == ["All"]:
+            result.append(ev)
+        elif any(h.lower() == name_lower for h in hermits):
+            result.append(ev)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Recap assembler
 # ---------------------------------------------------------------------------
@@ -443,19 +465,21 @@ def format_timeline_text(
     season: int,
     events: list[dict],
     month: int | None = None,
+    hermit: str | None = None,
 ) -> str:
     """
     Return a human-readable chronological timeline for *season*.
 
     Each event line shows: date, hermit(s), title.
     A description block follows each entry.
-    *month*, if given, is used only in the header label.
+    *month* and *hermit*, if given, are used only in the header label.
     """
     lines: list[str] = []
 
     month_label = f" — {_MONTH_NAMES[month]}" if month and 1 <= month <= 12 else ""
+    hermit_label = f" — {hermit}" if hermit else ""
     lines.append(_hr("═"))
-    lines.append(f"  HERMITCRAFT SEASON {season} TIMELINE{month_label}")
+    lines.append(f"  HERMITCRAFT SEASON {season} TIMELINE{month_label}{hermit_label}")
     lines.append(_hr("═"))
 
     if not events:
@@ -546,6 +570,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output only the chronological event timeline (no full recap)",
     )
     parser.add_argument(
+        "--hermit",
+        metavar="NAME",
+        help=(
+            "Filter timeline events to those involving a specific hermit. "
+            "Case-insensitive. Server-wide events (hermits=[All]) are always "
+            "included. Implies --timeline-only."
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         dest="as_json",
@@ -558,8 +591,8 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    # --month implies --timeline-only
-    if args.month is not None:
+    # --month and --hermit both imply --timeline-only
+    if args.month is not None or args.hermit is not None:
         args.timeline_only = True
 
     if args.list:
@@ -587,17 +620,22 @@ def main(argv: list[str] | None = None) -> int:
         events = load_events_for_season(season)
         if args.month is not None:
             events = filter_timeline_by_month(events, args.month)
+        if args.hermit is not None:
+            events = filter_by_hermit(events, args.hermit)
 
         if args.as_json:
             payload = {
                 "season": season,
                 "month": args.month,
+                "hermit": args.hermit,
                 "event_count": len(events),
                 "events": events,
             }
             print(json.dumps(payload, indent=2, ensure_ascii=False))
         else:
-            print(format_timeline_text(season, events, month=args.month))
+            print(format_timeline_text(
+                season, events, month=args.month, hermit=args.hermit
+            ))
         return 0
 
     # Full recap path


### PR DESCRIPTION
## Summary

Adds `--hermit NAME` to both `tools/season_recap.py` and `tools/on_this_day.py`, enabling per-hermit queries across the full event knowledge base.

**Filter logic (identical in both tools):**
- Events with `hermits == ["All"]` are **always included** (server-wide events affect everyone)
- Events listing the hermit by name are included (**case-insensitive**)
- Events with an empty hermit list are excluded (unknown participants)

## Example queries

```sh
# What events involve TangoTek in Season 7?
python3 tools/season_recap.py --season 7 --hermit TangoTek

# Grian's events on April 13 across all years
python3 tools/on_this_day.py --month 4 --day 13 --all-events --hermit Grian

# Machine-readable: Grian's Season 7 events
python3 tools/season_recap.py --season 7 --hermit Grian --json

# Combined: Grian's Season 7 events in June
python3 tools/season_recap.py --season 7 --hermit Grian --month 6 --json
```

## Output sample

```
════════════════════════════════════════════════════════════
  HERMITCRAFT SEASON 7 TIMELINE — TangoTek
════════════════════════════════════════════════════════════

  2020  [TangoTek]
  Decked Out Opens
    TangoTek builds and opens Decked Out — a dungeon-crawler card game
    considered one of the greatest Minecraft creations ever.
  ························································

  2020-02-28  [All]
  Season 7 Launch
  ...
```

## Changes

| File | What changed |
|---|---|
| `tools/season_recap.py` | `filter_by_hermit()`, `--hermit` flag (implies `--timeline-only`), hermit label in header, `hermit` field in JSON payload |
| `tools/on_this_day.py` | `filter_by_hermit()`, `--hermit` flag applied after `find_on_this_day()` |
| `tests/test_season_recap.py` | `TestFilterByHermit` (10 unit), `TestCLIHermit` (8 CLI) |
| `tests/test_on_this_day.py` | `TestFilterByHermit` (9 unit), `TestFilterByHermitCLI` (5 CLI) |

## Tests

28 new tests across both files — 238 total, all passing.

Key coverage:
- `["All"]` events always pass through
- Named hermit inclusion (exact + multi-hermit events)
- Non-matching hermit exclusion
- Empty hermit list exclusion
- Case-insensitive matching (lower / UPPER / Mixed)
- `--hermit` combined with `--month` in both text and JSON modes
- Verified TangoTek gets "Decked Out" event in Season 7

## Test plan

- [ ] `python3 tools/season_recap.py --season 7 --hermit TangoTek` shows Decked Out + server-wide events only
- [ ] `python3 tools/season_recap.py --season 7 --hermit grian --json` returns `"hermit": "grian"` and only Grian-relevant events
- [ ] `python3 tools/on_this_day.py --month 4 --day 13 --all-events --hermit Generikb` returns founding + Generikb events
- [ ] All 238 tests pass

Closes #78