### PR TITLE
[hermitcraft-agent] Add --digest flag to on_this_day for bot/Discord-ready text output

### DIFF
--- a/tests/test_on_this_day.py
+++ b/tests/test_on_this_day.py
@@ -20,6 +20,7 @@ from tools.on_this_day import (
     _parse_frontmatter,
     filter_by_hermit,
     find_on_this_day,
+    format_digest,
     load_events,
     load_hermit_profiles,
     matches_on_this_day,
@@ -1044,6 +1045,188 @@ class TestFilterByHermitCLI(unittest.TestCase):
             for line in result.stdout.strip().splitlines():
                 obj = json.loads(line)
                 self.assertIn("id", obj)
+
+
+# ---------------------------------------------------------------------------
+# TestFormatDigest — unit tests for format_digest()
+# ---------------------------------------------------------------------------
+
+class TestFormatDigest(unittest.TestCase):
+    """Tests for the format_digest() human-readable output function."""
+
+    SAMPLE_EVENTS = [
+        _make_event(
+            id="s1-001", date="2012-04-13", date_precision="day",
+            season=1, hermits=["Generikb", "Xisumavoid"],
+            event_type="milestone", title="Hermitcraft Server Founded",
+            description="Generikb launches Hermitcraft with ten founding members.",
+        ),
+        _make_event(
+            id="s7-001", date="2020-02-28", date_precision="day",
+            season=7, hermits=["All"],
+            event_type="milestone", title="Season 7 Launch",
+            description="Season 7 launches during COVID-19 lockdowns.",
+        ),
+    ]
+
+    def test_returns_string(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIsInstance(out, str)
+
+    def test_header_contains_date(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("April 13", out)
+
+    def test_header_contains_on_this_day(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("ON THIS DAY IN HERMITCRAFT", out)
+
+    def test_event_title_present(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("Hermitcraft Server Founded", out)
+        self.assertIn("Season 7 Launch", out)
+
+    def test_year_label_present(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("[2012]", out)
+        self.assertIn("[2020]", out)
+
+    def test_season_label_present(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("Season 1", out)
+        self.assertIn("Season 7", out)
+
+    def test_hermit_names_present(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("Generikb", out)
+        self.assertIn("All", out)
+
+    def test_description_present(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("ten founding members", out)
+
+    def test_event_count_in_footer(self):
+        out = format_digest(self.SAMPLE_EVENTS, 4, 13)
+        self.assertIn("2 events found", out)
+
+    def test_single_event_singular_label(self):
+        out = format_digest(self.SAMPLE_EVENTS[:1], 4, 13)
+        self.assertIn("1 event found", out)
+        self.assertNotIn("1 events found", out)
+
+    def test_empty_events_shows_nothing_recorded(self):
+        out = format_digest([], 4, 13)
+        self.assertIn("Nothing recorded", out)
+
+    def test_empty_events_contains_hint(self):
+        out = format_digest([], 4, 13)
+        self.assertIn("--all-events", out)
+
+    def test_different_month_days(self):
+        out2 = format_digest([], 6, 19)
+        self.assertIn("June 19", out2)
+        out3 = format_digest([], 12, 22)
+        self.assertIn("December 22", out3)
+
+    def test_pre_hermitcraft_season_label(self):
+        pre_event = _make_event(
+            id="pre-1", date="2010-01-01", season=0,
+            hermits=["EthosLab"], event_type="milestone",
+            title="EthosLab Starts YouTube",
+        )
+        out = format_digest([pre_event], 1, 1)
+        self.assertIn("pre-Hermitcraft", out)
+
+
+# ---------------------------------------------------------------------------
+# TestDigestCLI — CLI tests for --digest flag
+# ---------------------------------------------------------------------------
+
+class TestDigestCLI(unittest.TestCase):
+    """End-to-end tests for the --digest CLI flag."""
+
+    SCRIPT = str(ROOT / "tools" / "on_this_day.py")
+
+    def _run(self, *args: str):
+        return subprocess.run(
+            [sys.executable, self.SCRIPT, *args],
+            capture_output=True, text=True,
+        )
+
+    def test_digest_exits_0_on_known_premiere_date(self):
+        # Feb 28 = Season 7 launch; Season 4 launch — known premiere date
+        result = self._run("--month", "2", "--day", "28", "--digest")
+        self.assertEqual(result.returncode, 0)
+
+    def test_digest_exits_0_on_server_founding_date(self):
+        result = self._run("--month", "4", "--day", "13", "--digest")
+        self.assertEqual(result.returncode, 0)
+
+    def test_digest_output_contains_on_this_day_header(self):
+        result = self._run("--month", "4", "--day", "13", "--digest")
+        self.assertIn("ON THIS DAY IN HERMITCRAFT", result.stdout)
+
+    def test_digest_output_contains_date(self):
+        result = self._run("--month", "4", "--day", "13", "--digest")
+        self.assertIn("April 13", result.stdout)
+
+    def test_digest_output_contains_event_count(self):
+        result = self._run("--month", "4", "--day", "13", "--digest")
+        self.assertIn("event", result.stdout)
+
+    def test_digest_sparse_date_exits_1(self):
+        # Very narrow window on a date with no known events
+        result = self._run("--month", "1", "--day", "15", "--window", "0", "--digest")
+        self.assertEqual(result.returncode, 1)
+
+    def test_digest_sparse_date_prints_nothing_recorded(self):
+        result = self._run("--month", "1", "--day", "15", "--window", "0", "--digest")
+        self.assertIn("Nothing recorded", result.stdout)
+
+    def test_digest_sparse_date_no_stderr(self):
+        # With --digest, "nothing found" goes to stdout, not stderr
+        result = self._run("--month", "1", "--day", "15", "--window", "0", "--digest")
+        self.assertEqual(result.stderr, "")
+
+    def test_digest_all_events_returns_more_than_default(self):
+        default = self._run("--month", "4", "--day", "13", "--digest")
+        all_ev = self._run("--month", "4", "--day", "13", "--all-events", "--digest")
+        if default.returncode == 0 and all_ev.returncode == 0:
+            # Count lines as proxy for event count
+            self.assertGreaterEqual(
+                len(all_ev.stdout.splitlines()),
+                len(default.stdout.splitlines()),
+            )
+
+    def test_digest_output_is_not_json(self):
+        result = self._run("--month", "4", "--day", "13", "--digest")
+        self.assertEqual(result.returncode, 0)
+        # Should not be parseable as JSON
+        with self.assertRaises((json.JSONDecodeError, ValueError)):
+            json.loads(result.stdout)
+
+    def test_digest_combined_with_hermit_filter(self):
+        result = self._run(
+            "--month", "4", "--day", "13",
+            "--all-events", "--hermit", "Grian", "--digest",
+        )
+        # Exit 0 since Grian appears in events on this date
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ON THIS DAY IN HERMITCRAFT", result.stdout)
+
+    def test_digest_and_pretty_are_independent(self):
+        # --digest should produce text; --pretty produces JSON array
+        digest_result = self._run("--month", "4", "--day", "13", "--digest")
+        pretty_result = self._run("--month", "4", "--day", "13", "--pretty")
+        self.assertIn("ON THIS DAY", digest_result.stdout)
+        # pretty output should be valid JSON
+        json.loads(pretty_result.stdout)
+
+    def test_digest_known_finale_date_s9(self):
+        # Dec 20 = Season 9 finale
+        result = self._run("--month", "12", "--day", "20", "--digest")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("event", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tools/on_this_day.py
+++ b/tools/on_this_day.py
@@ -16,6 +16,7 @@ Usage
   python3 tools/on_this_day.py --include-year                  # include year-only events
   python3 tools/on_this_day.py --include-hermit-anniversaries  # add hermit join/YT/subscriber anniversaries
   python3 tools/on_this_day.py --include-video-events          # add notable video/stream milestone events
+  python3 tools/on_this_day.py --digest                        # human-readable text digest (bot/Discord-ready)
   python3 tools/on_this_day.py --pretty                        # indented JSON array output
 
 Date precision handling
@@ -30,6 +31,7 @@ Output
 ------
 Newline-delimited JSON objects (NDJSON) sorted oldest-year-first.
 Use --pretty for a formatted JSON array.
+Use --digest for a human-readable text digest suitable for bots or terminals.
 
 Exit codes
 ----------
@@ -375,6 +377,85 @@ def filter_by_hermit(events: list[dict], hermit_name: str) -> list[dict]:
     return result
 
 
+_MONTH_NAMES = [
+    "", "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]
+
+
+def format_digest(events: list[dict], month: int, day: int) -> str:
+    """
+    Return a human-readable "On This Day" digest string.
+
+    Suitable for terminal output, daily bots, or Discord posts.
+    Each event block shows: year, season, type, title, hermits,
+    and a word-wrapped description.
+
+    If *events* is empty a friendly "quiet day" message is returned;
+    the caller is still responsible for returning exit code 1.
+    """
+    hr_heavy = "═" * 60
+    hr_light = "─" * 58
+
+    month_name = _MONTH_NAMES[month] if 1 <= month <= 12 else str(month)
+    date_label = f"{month_name} {day}"
+
+    lines: list[str] = []
+    lines.append(hr_heavy)
+    lines.append("  ON THIS DAY IN HERMITCRAFT")
+    lines.append(f"  {date_label}")
+    lines.append(hr_heavy)
+
+    if not events:
+        lines.append("")
+        lines.append("  Nothing recorded in Hermitcraft history for this date.")
+        lines.append("  (Try --all-events or widen with --window)")
+        lines.append("")
+        lines.append(hr_heavy)
+        return "\n".join(lines)
+
+    for ev in events:
+        year, *_ = ev.get("date", "").split("-") + [""]
+        season = ev.get("season", 0)
+        ev_type = ev.get("type", "")
+        title = ev.get("title", "")
+        hermits: list = ev.get("hermits", [])
+        description = ev.get("description", "")
+
+        year_label = f"[{year}]" if year and year.isdigit() else "[?]"
+        season_label = f"Season {season}" if season else "pre-Hermitcraft"
+        type_label = ev_type if ev_type else "event"
+        hermit_str = ", ".join(hermits) if hermits else "unknown"
+
+        lines.append("")
+        lines.append(f"  {year_label}  {season_label}  ·  {type_label}")
+        lines.append(f"  {title}")
+        lines.append(f"  Hermits: {hermit_str}")
+        lines.append("  " + hr_light)
+
+        # Word-wrap description to ~76 chars
+        if description:
+            words = description.split()
+            row = ""
+            for w in words:
+                if len(row) + len(w) + 1 > 74:
+                    lines.append("  " + row)
+                    row = w
+                else:
+                    row = (row + " " + w).strip()
+            if row:
+                lines.append("  " + row)
+
+        lines.append("  " + hr_light)
+
+    lines.append("")
+    count = len(events)
+    lines.append(hr_heavy)
+    lines.append(f"  {count} event{'s' if count != 1 else ''} found")
+    lines.append(hr_heavy)
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="On This Day in Hermitcraft — historical event digest",
@@ -433,6 +514,14 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--digest", action="store_true",
+        help=(
+            "Output a human-readable text digest instead of JSON. "
+            "Suitable for terminal display, daily bots, or Discord posts. "
+            "Prints a friendly 'nothing found' message (exit 1) on empty results."
+        ),
+    )
+    parser.add_argument(
         "--pretty", action="store_true",
         help="Output a pretty-printed JSON array instead of NDJSON.",
     )
@@ -481,13 +570,18 @@ def main(argv: list[str] | None = None) -> int:
         results = filter_by_hermit(results, args.hermit)
 
     if not results:
-        sys.stderr.write(
-            f"[on_this_day] no events found for "
-            f"{target_month:02d}-{target_day:02d} (±{args.window} days)\n"
-        )
+        if args.digest:
+            print(format_digest([], target_month, target_day))
+        else:
+            sys.stderr.write(
+                f"[on_this_day] no events found for "
+                f"{target_month:02d}-{target_day:02d} (±{args.window} days)\n"
+            )
         return 1
 
-    if args.pretty:
+    if args.digest:
+        print(format_digest(results, target_month, target_day))
+    elif args.pretty:
         print(json.dumps(results, indent=2))
     else:
         for event in results:


### PR DESCRIPTION
## Summary

`tools/on_this_day.py` already handles the "On This Day" lookup (it has since the beginning), but only outputs NDJSON or JSON array — not human-readable text. This PR adds `--digest` for a formatted output suitable for terminal display, daily bots, or Discord posts.

## Example output

```
$ python3 tools/on_this_day.py --month 4 --day 13 --digest
════════════════════════════════════════════════════════════
  ON THIS DAY IN HERMITCRAFT
  April 13
════════════════════════════════════════════════════════════

  [2012]  Season 1  ·  milestone
  Hermitcraft Server Founded
  Hermits: Generikb, Xisumavoid, Hypnotizd, ...
  ──────────────────────────────────────────────────────────
  Generikb launches Hermitcraft on Minecraft 1.2.5 with ten
  founding members...
  ──────────────────────────────────────────────────────────
  ...
════════════════════════════════════════════════════════════
  3 events found
════════════════════════════════════════════════════════════
```

## Sparse-date behaviour

```
$ python3 tools/on_this_day.py --month 1 --day 15 --window 0 --digest; echo $?
════════════════════════════════════════════════════════════
  ON THIS DAY IN HERMITCRAFT
  January 15
════════════════════════════════════════════════════════════

  Nothing recorded in Hermitcraft history for this date.
  (Try --all-events or widen with --window)

════════════════════════════════════════════════════════════
1
```

**Key bot-friendly detail**: with `--digest`, "nothing found" prints to **stdout** (not stderr), so a bot can capture and re-post it directly. Exit code 1 is preserved for scripted detection.

## Acceptance criteria (from #80)

- [x] Returns results on known premiere dates (Feb 28 = S7/S4 launch; Apr 13 = server founding)
- [x] Returns results on known finale dates (Dec 20 = S9 finale; Dec 22 = S8 finale)
- [x] Gracefully returns "Nothing recorded" message for sparse dates
- [x] Composes with `--all-events`, `--hermit`, `--window` flags

## New function

`format_digest(events, month, day) -> str` — pure function, no I/O, fully testable.

## Tests

27 new tests (152 total, all passing):
- **`TestFormatDigest`** (14 unit): header, date label, year/season/type labels, hermit names, description, event count, singular/plural grammar, empty case, hint text, pre-Hermitcraft label, multiple month/day combinations
- **`TestDigestCLI`** (13 end-to-end): founding date, premiere/finale dates, sparse date (exit 1 + stdout), no-stderr guarantee, `--all-events` superset, not-JSON assertion, `--hermit` composition, `--pretty` independence

## Test plan

- [ ] `python3 tools/on_this_day.py --month 4 --day 13 --digest` shows server founding event(s)
- [ ] `python3 tools/on_this_day.py --month 2 --day 28 --digest` shows S7 launch
- [ ] `python3 tools/on_this_day.py --month 1 --day 15 --window 0 --digest` prints "Nothing recorded", exits 1, no stderr
- [ ] All 152 tests pass

Closes #80