### PR TITLE
[hermitcraft-agent] Add keyword search across episodes and events

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,510 @@
+"""
+Tests for tools/search.py
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.search import (
+    ALL_SOURCES,
+    EVENTS_FILE,
+    HERMITS_DIR,
+    SEASONS_DIR,
+    VIDEO_EVENTS_FILE,
+    _count_matches,
+    _tokenise_query,
+    format_search_results,
+    make_snippet,
+    run_search,
+    score_result,
+    search_events,
+    search_hermit_profiles,
+    search_season_files,
+)
+
+SCRIPT = str(Path(__file__).parent.parent / "tools" / "search.py")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _tokenise_query
+# ---------------------------------------------------------------------------
+
+class TestTokeniseQuery(unittest.TestCase):
+    def test_single_word(self):
+        self.assertEqual(_tokenise_query("grian"), ["grian"])
+
+    def test_multi_word(self):
+        self.assertEqual(_tokenise_query("Boatem Hole"), ["boatem", "hole"])
+
+    def test_extra_whitespace(self):
+        tokens = _tokenise_query("  decked   out  ")
+        self.assertEqual(tokens, ["decked", "out"])
+
+    def test_empty_string(self):
+        self.assertEqual(_tokenise_query(""), [])
+
+    def test_case_lowered(self):
+        tokens = _tokenise_query("GRIAN MumboJumbo")
+        self.assertEqual(tokens, ["grian", "mumbojumbo"])
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _count_matches
+# ---------------------------------------------------------------------------
+
+class TestCountMatches(unittest.TestCase):
+    def test_single_match(self):
+        self.assertEqual(_count_matches("Grian pranked MumboJumbo", ["grian"]), 1)
+
+    def test_multiple_matches(self):
+        self.assertEqual(_count_matches("Decked Out is the best Decked Out", ["decked"]), 2)
+
+    def test_no_match(self):
+        self.assertEqual(_count_matches("nothing here", ["grian"]), 0)
+
+    def test_case_insensitive(self):
+        self.assertEqual(_count_matches("GRIAN and grian", ["grian"]), 2)
+
+    def test_multiple_tokens(self):
+        count = _count_matches("Grian and Scar went to Boatem", ["grian", "boatem"])
+        self.assertEqual(count, 2)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — score_result
+# ---------------------------------------------------------------------------
+
+class TestScoreResult(unittest.TestCase):
+    def test_title_match_worth_3x(self):
+        tokens = ["decked"]
+        s_title = score_result(tokens, "Decked Out", "nothing relevant")
+        s_body  = score_result(tokens, "Event Title", "decked out happened here")
+        self.assertEqual(s_title, 3)
+        self.assertEqual(s_body, 1)
+
+    def test_both_title_and_body(self):
+        tokens = ["grian"]
+        sc = score_result(tokens, "Grian Joins Season 6", "Grian first appears in Season 6")
+        # 1 title hit × 3 + 1 body hit × 1 = 4
+        self.assertEqual(sc, 4)
+
+    def test_no_match_returns_zero(self):
+        self.assertEqual(score_result(["xyz"], "Title", "body text"), 0)
+
+    def test_empty_tokens_returns_zero(self):
+        self.assertEqual(score_result([], "Title with words", "body"), 0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — make_snippet
+# ---------------------------------------------------------------------------
+
+class TestMakeSnippet(unittest.TestCase):
+    def test_snippet_includes_keyword_context(self):
+        text = "This is a long introduction. TangoTek built Decked Out. More words follow here."
+        snippet = make_snippet(text, ["decked"])
+        self.assertIn("Decked", snippet)
+
+    def test_snippet_respects_max_len(self):
+        text = "a " * 200
+        snippet = make_snippet(text, ["zzz"], max_len=50)
+        self.assertLessEqual(len(snippet), 60)  # some slack for "..."
+
+    def test_ellipsis_when_truncated(self):
+        text = "start " + "filler " * 50 + "keyword here " + "filler " * 50 + "end"
+        snippet = make_snippet(text, ["keyword"])
+        self.assertIn("keyword", snippet.lower())
+
+    def test_empty_text(self):
+        self.assertEqual(make_snippet("", ["grian"]), "")
+
+    def test_no_match_returns_start(self):
+        text = "Season 7 launched in 2020 with 24 members."
+        snippet = make_snippet(text, ["nonexistent"])
+        self.assertTrue(snippet.startswith("Season 7"))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — search_events
+# ---------------------------------------------------------------------------
+
+class TestSearchEvents(unittest.TestCase):
+    def test_decked_out_returns_results(self):
+        results = search_events(["decked", "out"])
+        self.assertGreater(len(results), 0)
+
+    def test_each_result_has_required_fields(self):
+        results = search_events(["season"])
+        for r in results:
+            for field in ("source", "score", "season", "hermits", "id", "title", "snippet"):
+                self.assertIn(field, r, f"Missing field '{field}'")
+
+    def test_source_field_is_event(self):
+        results = search_events(["decked"])
+        for r in results:
+            self.assertEqual(r["source"], "event")
+
+    def test_all_scores_positive(self):
+        results = search_events(["grian"])
+        for r in results:
+            self.assertGreater(r["score"], 0)
+
+    def test_season_filter_applied(self):
+        results = search_events(["season"], season_filter=7)
+        for r in results:
+            self.assertEqual(r["season"], 7)
+
+    def test_no_match_returns_empty(self):
+        results = search_events(["xyzzy_no_match_ever"])
+        self.assertEqual(results, [])
+
+    def test_tangotek_decked_out_season7(self):
+        results = search_events(["decked", "out"], season_filter=7)
+        titles = [r["title"] for r in results]
+        self.assertTrue(any("Decked Out" in t for t in titles))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — search_hermit_profiles
+# ---------------------------------------------------------------------------
+
+class TestSearchHermitProfiles(unittest.TestCase):
+    def test_grian_found_by_name(self):
+        results = search_hermit_profiles(["grian"])
+        names = [r["hermits"][0] for r in results if r["hermits"]]
+        self.assertIn("Grian", names)
+
+    def test_source_field_is_hermit_profile(self):
+        results = search_hermit_profiles(["mumbo"])
+        for r in results:
+            self.assertEqual(r["source"], "hermit_profile")
+
+    def test_season_filter_excludes_non_members(self):
+        # Season 1 had a very different roster; most modern hermits weren't there
+        results_s1 = search_hermit_profiles(["building"], season_filter=1)
+        results_all = search_hermit_profiles(["building"])
+        # Season 1 filter should return fewer results than no filter
+        self.assertLessEqual(len(results_s1), len(results_all))
+
+    def test_redstone_finds_mumbo(self):
+        results = search_hermit_profiles(["redstone"])
+        names = [r["hermits"][0] for r in results if r["hermits"]]
+        self.assertIn("MumboJumbo", names)
+
+    def test_each_result_has_required_fields(self):
+        results = search_hermit_profiles(["grian"])
+        for r in results:
+            for field in ("source", "score", "hermits", "id", "title", "snippet"):
+                self.assertIn(field, r)
+
+    def test_no_match_returns_empty(self):
+        results = search_hermit_profiles(["xyzzy_no_match_ever"])
+        self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — search_season_files
+# ---------------------------------------------------------------------------
+
+class TestSearchSeasonFiles(unittest.TestCase):
+    def test_mycelium_resistance_found(self):
+        results = search_season_files(["mycelium"])
+        self.assertGreater(len(results), 0)
+
+    def test_source_is_season_file(self):
+        results = search_season_files(["decked"])
+        for r in results:
+            self.assertEqual(r["source"], "season_file")
+
+    def test_season_filter(self):
+        results = search_season_files(["decked"], season_filter=7)
+        for r in results:
+            self.assertEqual(r["season"], 7)
+
+    def test_boatem_found_in_season8(self):
+        results = search_season_files(["boatem"])
+        seasons = [r["season"] for r in results]
+        self.assertIn(8, seasons)
+
+    def test_each_result_has_season_number(self):
+        results = search_season_files(["launched"])
+        for r in results:
+            self.assertIsNotNone(r["season"])
+            self.assertIsInstance(r["season"], int)
+
+    def test_no_match_returns_empty(self):
+        results = search_season_files(["xyzzy_no_match_ever"])
+        self.assertEqual(results, [])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — run_search
+# ---------------------------------------------------------------------------
+
+class TestRunSearch(unittest.TestCase):
+    def test_boatem_hole_returns_results(self):
+        results = run_search("Boatem Hole")
+        self.assertGreater(len(results), 0)
+
+    def test_results_sorted_by_score_descending(self):
+        results = run_search("Decked Out")
+        scores = [r["score"] for r in results]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_season_filter_applied_across_sources(self):
+        results = run_search("season", season_filter=7)
+        # Every result that has a season field must equal 7
+        # (hermit profile results have season=None — those are cross-season)
+        for r in results:
+            if r["season"] is not None:
+                self.assertEqual(r["season"], 7,
+                                 f"Expected season 7, got {r['season']} for {r['title']}")
+
+    def test_sources_filter_events_only(self):
+        results = run_search("grian", sources=["events"])
+        for r in results:
+            self.assertEqual(r["source"], "event")
+
+    def test_sources_filter_hermits_only(self):
+        results = run_search("building", sources=["hermits"])
+        for r in results:
+            self.assertEqual(r["source"], "hermit_profile")
+
+    def test_limit_respected(self):
+        results = run_search("the", limit=3)
+        self.assertLessEqual(len(results), 3)
+
+    def test_no_match_returns_empty(self):
+        results = run_search("xyzzy_no_match_ever")
+        self.assertEqual(results, [])
+
+    def test_empty_query_returns_empty(self):
+        results = run_search("")
+        self.assertEqual(results, [])
+
+    def test_all_results_have_season_and_hermits(self):
+        results = run_search("Grian")
+        for r in results:
+            self.assertIn("season", r)
+            self.assertIn("hermits", r)
+
+    def test_mycelium_resistance_results_include_season7(self):
+        results = run_search("Mycelium Resistance")
+        seasons = [r["season"] for r in results if r["season"] is not None]
+        self.assertIn(7, seasons)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — format_search_results
+# ---------------------------------------------------------------------------
+
+class TestFormatSearchResults(unittest.TestCase):
+    def setUp(self):
+        self.results = run_search("Decked Out")
+
+    def test_returns_string(self):
+        out = format_search_results("Decked Out", self.results)
+        self.assertIsInstance(out, str)
+
+    def test_query_in_header(self):
+        out = format_search_results("Decked Out", self.results)
+        self.assertIn("Decked Out", out)
+
+    def test_result_count_in_header(self):
+        out = format_search_results("Decked Out", self.results)
+        self.assertIn(str(len(self.results)), out)
+
+    def test_titles_present(self):
+        out = format_search_results("Decked Out", self.results)
+        # At least one result title should appear
+        for r in self.results[:3]:
+            # Title might be truncated, check first 20 chars
+            self.assertIn(r["title"][:20], out)
+
+    def test_empty_results_shows_no_matches(self):
+        out = format_search_results("xyzzy", [])
+        self.assertIn("No matches found", out)
+
+    def test_singular_result_label(self):
+        single = run_search("Decked Out", limit=1)
+        out = format_search_results("Decked Out", single)
+        self.assertIn("1 result found", out)
+
+    def test_plural_result_label(self):
+        multi = run_search("Decked Out", limit=5)
+        if len(multi) > 1:
+            out = format_search_results("Decked Out", multi)
+            self.assertIn("results found", out)
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+class TestCLI(unittest.TestCase):
+    def _run(self, *args: str) -> tuple[int, str, str]:
+        result = subprocess.run(
+            [sys.executable, SCRIPT, *args],
+            capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def test_basic_query_exits_0(self):
+        rc, _, _ = self._run("--query", "Decked Out")
+        self.assertEqual(rc, 0)
+
+    def test_no_match_exits_1(self):
+        rc, _, _ = self._run("--query", "xyzzy_no_match_ever_12345")
+        self.assertEqual(rc, 1)
+
+    def test_no_args_exits_nonzero(self):
+        rc, _, _ = self._run()
+        self.assertNotEqual(rc, 0)
+
+    def test_text_output_contains_header(self):
+        _, stdout, _ = self._run("--query", "Boatem")
+        self.assertIn("HERMITCRAFT SEARCH", stdout)
+
+    def test_text_output_contains_query(self):
+        _, stdout, _ = self._run("--query", "Boatem")
+        self.assertIn("Boatem", stdout)
+
+    def test_json_flag_valid_json(self):
+        rc, stdout, _ = self._run("--query", "Grian", "--json")
+        self.assertEqual(rc, 0)
+        data = json.loads(stdout)
+        self.assertIn("results", data)
+        self.assertIn("result_count", data)
+        self.assertIn("query", data)
+
+    def test_json_results_have_required_fields(self):
+        _, stdout, _ = self._run("--query", "Decked Out", "--json")
+        data = json.loads(stdout)
+        for r in data["results"]:
+            for field in ("source", "score", "season", "hermits", "title"):
+                self.assertIn(field, r, f"Missing field '{field}' in result")
+
+    def test_season_filter(self):
+        _, stdout, _ = self._run("--query", "builds", "--season", "7", "--json")
+        data = json.loads(stdout)
+        for r in data["results"]:
+            if r["season"] is not None:
+                self.assertEqual(r["season"], 7)
+
+    def test_sources_events_only(self):
+        _, stdout, _ = self._run("--query", "grian", "--sources", "events", "--json")
+        data = json.loads(stdout)
+        for r in data["results"]:
+            self.assertEqual(r["source"], "event")
+
+    def test_sources_hermits_only(self):
+        _, stdout, _ = self._run("--query", "building", "--sources", "hermits", "--json")
+        data = json.loads(stdout)
+        for r in data["results"]:
+            self.assertEqual(r["source"], "hermit_profile")
+
+    def test_limit_flag(self):
+        _, stdout, _ = self._run("--query", "the", "--limit", "3", "--json")
+        data = json.loads(stdout)
+        self.assertLessEqual(data["result_count"], 3)
+
+    def test_results_sorted_by_score(self):
+        _, stdout, _ = self._run("--query", "Decked Out", "--json")
+        data = json.loads(stdout)
+        scores = [r["score"] for r in data["results"]]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_mycelium_resistance_returns_season7(self):
+        _, stdout, _ = self._run("--query", "Mycelium Resistance", "--json")
+        data = json.loads(stdout)
+        seasons = [r["season"] for r in data["results"] if r["season"] is not None]
+        self.assertIn(7, seasons)
+
+    def test_hermit_attribution_present(self):
+        _, stdout, _ = self._run("--query", "TangoTek Decked Out", "--json")
+        data = json.loads(stdout)
+        # At least one result should attribute TangoTek
+        attributed = any(
+            "TangoTek" in r.get("hermits", []) or "TangoTek" in r.get("title", "")
+            for r in data["results"]
+        )
+        self.assertTrue(attributed, "Expected TangoTek attribution in results")
+
+    def test_no_match_text_output(self):
+        _, stdout, _ = self._run("--query", "xyzzy_no_match_ever_12345")
+        self.assertIn("No matches found", stdout)
+
+    def test_short_flag_for_query(self):
+        rc, _, _ = self._run("-q", "Grian")
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# Constants / data integrity tests
+# ---------------------------------------------------------------------------
+
+class TestDataIntegrity(unittest.TestCase):
+    def test_all_sources_constant(self):
+        self.assertEqual(set(ALL_SOURCES), {"events", "hermits", "seasons"})
+
+    def test_events_file_exists(self):
+        self.assertTrue(EVENTS_FILE.exists())
+
+    def test_video_events_file_exists(self):
+        self.assertTrue(VIDEO_EVENTS_FILE.exists())
+
+    def test_hermits_dir_exists(self):
+        self.assertTrue(HERMITS_DIR.exists())
+
+    def test_seasons_dir_exists(self):
+        self.assertTrue(SEASONS_DIR.exists())
+
+    def test_events_are_searchable(self):
+        results = search_events(["hermitcraft"])
+        self.assertGreater(len(results), 0)
+
+    def test_hermit_profiles_are_searchable(self):
+        results = search_hermit_profiles(["hermitcraft"])
+        self.assertGreater(len(results), 0)
+
+    def test_season_files_are_searchable(self):
+        results = search_season_files(["season"])
+        self.assertGreater(len(results), 0)
+
+
+if __name__ == "__main__":
+    import traceback
+
+    suites = [
+        ("_tokenise_query",   unittest.TestLoader().loadTestsFromTestCase(TestTokeniseQuery)),
+        ("_count_matches",    unittest.TestLoader().loadTestsFromTestCase(TestCountMatches)),
+        ("score_result",      unittest.TestLoader().loadTestsFromTestCase(TestScoreResult)),
+        ("make_snippet",      unittest.TestLoader().loadTestsFromTestCase(TestMakeSnippet)),
+        ("search_events",     unittest.TestLoader().loadTestsFromTestCase(TestSearchEvents)),
+        ("search_hermits",    unittest.TestLoader().loadTestsFromTestCase(TestSearchHermitProfiles)),
+        ("search_seasons",    unittest.TestLoader().loadTestsFromTestCase(TestSearchSeasonFiles)),
+        ("run_search",        unittest.TestLoader().loadTestsFromTestCase(TestRunSearch)),
+        ("format_results",    unittest.TestLoader().loadTestsFromTestCase(TestFormatSearchResults)),
+        ("CLI",               unittest.TestLoader().loadTestsFromTestCase(TestCLI)),
+        ("data_integrity",    unittest.TestLoader().loadTestsFromTestCase(TestDataIntegrity)),
+    ]
+
+    passed = failed = 0
+    for label, suite in suites:
+        print(f"{label}:")
+        for test in suite:
+            try:
+                test.debug()
+                print(f"  PASS {test._testMethodName}")
+                passed += 1
+            except Exception as exc:
+                print(f"  FAIL {test._testMethodName}: {exc}")
+                failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)

--- a/tools/search.py
+++ b/tools/search.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""
+Hermitcraft Knowledge Search
+=============================
+Search across Hermitcraft season events, hermit profiles, and season
+files for one or more keywords. Results are ranked by relevance and
+include season number and hermit attribution.
+
+Usage
+-----
+  python3 tools/search.py --query "Boatem Hole"
+  python3 tools/search.py --query "prank Grian" --json
+  python3 tools/search.py --query "Decked Out" --season 7
+  python3 tools/search.py --query "redstone" --sources events hermits
+  python3 tools/search.py --query "mycelium" --limit 5
+
+Sources searched (default: all)
+---------------------------------
+  events    — knowledge/timelines/events.json
+              + knowledge/timelines/video_events.json
+  hermits   — knowledge/hermits/*.md  (profiles)
+  seasons   — knowledge/seasons/*.md  (season summaries)
+
+Ranking
+-------
+  Title / heading matches score 3×; description / body matches score 1×.
+  Query is split on whitespace; each word is searched independently (OR
+  logic). Results with more keyword matches rank higher.
+
+Output
+------
+  Default: human-readable text digest.
+  --json : machine-readable JSON object with a "results" array.
+
+Exit codes
+----------
+  0  success (≥1 results)
+  1  no results found
+  2  bad arguments or missing data files
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).parent.parent
+EVENTS_FILE = ROOT / "knowledge" / "timelines" / "events.json"
+VIDEO_EVENTS_FILE = ROOT / "knowledge" / "timelines" / "video_events.json"
+HERMITS_DIR = ROOT / "knowledge" / "hermits"
+SEASONS_DIR = ROOT / "knowledge" / "seasons"
+
+ALL_SOURCES = ("events", "hermits", "seasons")
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+def _tokenise_query(query: str) -> list[str]:
+    """
+    Split *query* into a list of non-empty lowercase tokens.
+    Each token is searched independently (OR logic); higher total scores
+    indicate more keyword coverage.
+    """
+    return [w.lower() for w in query.split() if w.strip()]
+
+
+def _count_matches(text: str, tokens: list[str]) -> int:
+    """Return the total number of token occurrences in *text* (case-insensitive)."""
+    lower = text.lower()
+    return sum(lower.count(tok) for tok in tokens)
+
+
+def score_result(tokens: list[str], title: str, body: str) -> float:
+    """
+    Return a relevance score for a document with the given *title* and *body*.
+
+    Title hits are worth 3×; body hits are worth 1×.
+    """
+    return _count_matches(title, tokens) * 3 + _count_matches(body, tokens)
+
+
+def make_snippet(text: str, tokens: list[str], max_len: int = 160) -> str:
+    """
+    Return a short excerpt from *text* centred on the first token match.
+
+    If no token is found in *text*, returns the first *max_len* characters.
+    """
+    text_lower = text.lower()
+    best_pos: int | None = None
+    for tok in tokens:
+        pos = text_lower.find(tok)
+        if pos != -1 and (best_pos is None or pos < best_pos):
+            best_pos = pos
+
+    if best_pos is None:
+        raw = text[:max_len]
+    else:
+        start = max(0, best_pos - 60)
+        end = min(len(text), best_pos + max_len - 60)
+        raw = ("..." if start > 0 else "") + text[start:end] + ("..." if end < len(text) else "")
+
+    return re.sub(r"\s+", " ", raw).strip()
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (lightweight, no external deps)
+# ---------------------------------------------------------------------------
+
+def _parse_frontmatter(content: str) -> dict:
+    """Extract scalar fields from YAML-style ``---`` frontmatter."""
+    if not content.startswith("---"):
+        return {}
+    end = content.find("\n---", 3)
+    if end == -1:
+        return {}
+    result: dict = {}
+    for line in content[4:end].splitlines():
+        if not line.strip() or ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        value = raw.strip().strip('"').strip("'")
+        if value:
+            result[key.strip()] = value
+    return result
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Return *content* with the leading ``---`` frontmatter block removed."""
+    if not content.startswith("---"):
+        return content
+    end = content.find("\n---", 3)
+    return content[end + 4:] if end != -1 else content
+
+
+# ---------------------------------------------------------------------------
+# Per-source search functions
+# ---------------------------------------------------------------------------
+
+def search_events(tokens: list[str], season_filter: int | None = None) -> list[dict]:
+    """
+    Search ``events.json`` and ``video_events.json`` for *tokens*.
+
+    Each matching event becomes one result dict with keys:
+    source, score, season, hermits, id, title, snippet, date, type.
+    """
+    all_events: list[dict] = []
+    for path in (EVENTS_FILE, VIDEO_EVENTS_FILE):
+        if path.exists():
+            try:
+                all_events.extend(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    results = []
+    for ev in all_events:
+        season = ev.get("season")
+        if season_filter is not None and season != season_filter:
+            continue
+        title = ev.get("title", "")
+        body = ev.get("description", "")
+        sc = score_result(tokens, title, body)
+        if sc <= 0:
+            continue
+        results.append({
+            "source": "event",
+            "score": sc,
+            "season": season,
+            "hermits": ev.get("hermits", []),
+            "id": ev.get("id", ""),
+            "title": title,
+            "snippet": make_snippet(body, tokens) if body else "",
+            "date": ev.get("date", ""),
+            "type": ev.get("type", ""),
+        })
+    return results
+
+
+def search_hermit_profiles(
+    tokens: list[str],
+    season_filter: int | None = None,
+) -> list[dict]:
+    """
+    Search ``knowledge/hermits/*.md`` profile files for *tokens*.
+
+    If *season_filter* is given, only include hermits who played in that season
+    (checked via the ``seasons`` frontmatter list).
+    """
+    results = []
+    for path in sorted(HERMITS_DIR.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        fm = _parse_frontmatter(content)
+        name = fm.get("name", path.stem)
+
+        # Season filter: parse the "seasons:" field as a bracketed list
+        if season_filter is not None:
+            raw_seasons = fm.get("seasons", "")
+            season_nums = [
+                int(s) for s in re.findall(r"\d+", raw_seasons)
+            ]
+            if season_filter not in season_nums:
+                continue
+
+        body = _strip_frontmatter(content)
+        title = name
+        sc = score_result(tokens, title, body)
+        if sc <= 0:
+            continue
+
+        results.append({
+            "source": "hermit_profile",
+            "score": sc,
+            "season": None,
+            "hermits": [name],
+            "id": f"hermit-{re.sub(r'[^a-z0-9]', '', name.lower())}",
+            "title": f"{name} — Hermit Profile",
+            "snippet": make_snippet(body, tokens),
+            "date": fm.get("join_date", fm.get("joined_year", "")),
+            "type": "profile",
+        })
+    return results
+
+
+def search_season_files(
+    tokens: list[str],
+    season_filter: int | None = None,
+) -> list[dict]:
+    """
+    Search ``knowledge/seasons/season-N.md`` files for *tokens*.
+    """
+    results = []
+    for path in sorted(SEASONS_DIR.glob("season-*.md")):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        fm = _parse_frontmatter(content)
+        try:
+            season_num = int(fm.get("season", "0"))
+        except ValueError:
+            season_num = 0
+
+        if season_filter is not None and season_num != season_filter:
+            continue
+
+        body = _strip_frontmatter(content)
+        theme = fm.get("theme", "")
+        title = f"Season {season_num}" + (f" — {theme}" if theme else "")
+        sc = score_result(tokens, title, body)
+        if sc <= 0:
+            continue
+
+        results.append({
+            "source": "season_file",
+            "score": sc,
+            "season": season_num if season_num else None,
+            "hermits": [],
+            "id": f"season-{season_num}",
+            "title": title,
+            "snippet": make_snippet(body, tokens),
+            "date": fm.get("start_date", ""),
+            "type": "season_summary",
+        })
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Top-level search
+# ---------------------------------------------------------------------------
+
+def run_search(
+    query: str,
+    sources: list[str] | None = None,
+    season_filter: int | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """
+    Search *query* across the requested *sources*.
+
+    Returns a list of result dicts sorted by score (highest first),
+    capped at *limit* entries.
+    """
+    if sources is None:
+        sources = list(ALL_SOURCES)
+
+    tokens = _tokenise_query(query)
+    if not tokens:
+        return []
+
+    all_results: list[dict] = []
+
+    if "events" in sources:
+        all_results.extend(search_events(tokens, season_filter))
+    if "hermits" in sources:
+        all_results.extend(search_hermit_profiles(tokens, season_filter))
+    if "seasons" in sources:
+        all_results.extend(search_season_files(tokens, season_filter))
+
+    # Sort: score desc, then season asc (None seasons last), then id
+    def sort_key(r: dict) -> tuple:
+        season_sort = r["season"] if r["season"] is not None else 9999
+        return (-r["score"], season_sort, r["id"])
+
+    all_results.sort(key=sort_key)
+    return all_results[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Text formatter
+# ---------------------------------------------------------------------------
+
+def _hr(char: str = "─", width: int = 60) -> str:
+    return char * width
+
+
+def format_search_results(query: str, results: list[dict]) -> str:
+    """Return a human-readable search results string."""
+    lines: list[str] = []
+    lines.append(_hr("═"))
+    lines.append(f'  HERMITCRAFT SEARCH: "{query}"')
+    count = len(results)
+    lines.append(f"  {count} result{'s' if count != 1 else ''} found")
+    lines.append(_hr("═"))
+
+    if not results:
+        lines.append("")
+        lines.append("  No matches found. Try different keywords or --sources all.")
+        lines.append("")
+        lines.append(_hr("═"))
+        return "\n".join(lines)
+
+    for r in results:
+        score = r["score"]
+        source = r["source"]
+        season = r["season"]
+        hermits: list = r["hermits"]
+        title = r["title"]
+        snippet = r["snippet"]
+        date = r["date"]
+
+        season_label = f"Season {season}" if season else "cross-season"
+        hermit_str = ", ".join(hermits) if hermits else "—"
+        date_label = f"  ·  {date}" if date else ""
+
+        lines.append("")
+        lines.append(f"  [Score: {score}]  {source}  ·  {season_label}{date_label}")
+        lines.append(f"  {title}")
+        if hermits:
+            lines.append(f"  Hermits: {hermit_str}")
+        lines.append("  " + _hr("─", 56))
+        if snippet:
+            # Word-wrap snippet at ~76 chars
+            words = snippet.split()
+            row = ""
+            for w in words:
+                if len(row) + len(w) + 1 > 74:
+                    lines.append("  " + row)
+                    row = w
+                else:
+                    row = (row + " " + w).strip()
+            if row:
+                lines.append("  " + row)
+        lines.append("  " + _hr("─", 56))
+
+    lines.append("")
+    lines.append(_hr("═"))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="search",
+        description=(
+            "Search across Hermitcraft events, hermit profiles, and season "
+            "files for one or more keywords."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--query", "-q",
+        required=True,
+        metavar="KEYWORDS",
+        help="Search terms (space-separated, OR logic across terms).",
+    )
+    parser.add_argument(
+        "--sources",
+        nargs="+",
+        choices=list(ALL_SOURCES),
+        default=list(ALL_SOURCES),
+        metavar="SOURCE",
+        help=(
+            f"Which sources to search: {', '.join(ALL_SOURCES)}. "
+            "Default: all. Multiple values accepted."
+        ),
+    )
+    parser.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        help="Restrict search to a specific season number (1–11).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Maximum number of results to return (default: 20).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Output machine-readable JSON instead of text.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.limit < 1:
+        sys.stderr.write("[search] --limit must be ≥ 1\n")
+        return 2
+
+    results = run_search(
+        query=args.query,
+        sources=args.sources,
+        season_filter=args.season,
+        limit=args.limit,
+    )
+
+    if args.as_json:
+        payload = {
+            "query": args.query,
+            "sources": args.sources,
+            "season_filter": args.season,
+            "result_count": len(results),
+            "results": results,
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(format_search_results(args.query, results))
+
+    return 0 if results else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/search.py` — a ranked keyword search CLI covering all three knowledge-base sources: timeline events (`events.json` + `video_events.json`), hermit profiles (`knowledge/hermits/*.md`), and season summaries (`knowledge/seasons/*.md`)
- Title hits are weighted 3× body hits so the most relevant results surface first
- Supports `--sources events|hermits|seasons`, `--season N`, `--limit N`, and `--json` for machine-readable output
- Snippets show keyword-in-context (up to 160 chars) so results are immediately useful without opening the source file
- 79 unit tests in `tests/test_search.py` covering tokenisation, scoring, snippet extraction, all three search backends, `run_search`, `format_search_results`, CLI flags, and data-integrity checks

## Example usage

```
# Find all events related to Boatem Hole
python -m tools.search --query "Boatem Hole"

# Search only hermit profiles for redstone experts
python -m tools.search --query redstone --sources hermits

# Prank events involving Grian in season 6
python -m tools.search --query "prank Grian" --season 6 --sources events

# JSON output for bot/script consumption
python -m tools.search --query "Decked Out" --json
```

## Test plan

- [x] All 79 unit tests pass (`python3 -m unittest tests.test_search -v`)
- [x] Smoke-tested against live knowledge base (Boatem Hole, Decked Out, prank Grian)
- [x] `--json` output is valid JSON with `query`, `result_count`, `results` keys
- [x] `--season` filter correctly excludes results from other seasons
- [x] Empty query returns empty result list (no crash)

Closes #79