### PR TITLE
[hermitcraft-agent] Add hermit profile/biography endpoint

### DIFF
--- a/tests/test_hermit_profile.py
+++ b/tests/test_hermit_profile.py
@@ -1,0 +1,538 @@
+"""
+Tests for tools/hermit_profile.py
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.hermit_profile import (
+    HERMITS_DIR,
+    EVENTS_FILE,
+    VIDEO_EVENTS_FILE,
+    _normalise,
+    _parse_frontmatter,
+    _strip_frontmatter,
+    _extract_section,
+    _first_paragraph,
+    _extract_build_bullets,
+    list_hermits,
+    find_hermit_file,
+    load_profile,
+    load_hermit_events,
+    build_output,
+    format_profile_text,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalise
+# ---------------------------------------------------------------------------
+class TestNormalise(unittest.TestCase):
+    def test_lowercases(self):
+        self.assertEqual(_normalise("Grian"), "grian")
+
+    def test_strips_hyphens(self):
+        self.assertEqual(_normalise("mumbo-jumbo"), "mumbojumbo")
+
+    def test_strips_spaces(self):
+        self.assertEqual(_normalise("mumbo jumbo"), "mumbojumbo")
+
+    def test_strips_underscores(self):
+        self.assertEqual(_normalise("mumbo_jumbo"), "mumbojumbo")
+
+    def test_empty(self):
+        self.assertEqual(_normalise(""), "")
+
+
+# ---------------------------------------------------------------------------
+# _parse_frontmatter
+# ---------------------------------------------------------------------------
+class TestParseFrontmatter(unittest.TestCase):
+    def _make(self, block: str) -> str:
+        return f"---\n{block}\n---\n\nbody text"
+
+    def test_simple_scalar(self):
+        fm = _parse_frontmatter(self._make("name: Grian"))
+        self.assertEqual(fm["name"], "Grian")
+
+    def test_integer_field(self):
+        fm = _parse_frontmatter(self._make("joined_season: 6"))
+        self.assertEqual(fm["joined_season"], 6)
+
+    def test_quoted_scalar(self):
+        fm = _parse_frontmatter(self._make('join_date: "2018-07-19"'))
+        self.assertEqual(fm["join_date"], "2018-07-19")
+
+    def test_inline_list(self):
+        fm = _parse_frontmatter(self._make("seasons: [6, 7, 8]"))
+        self.assertEqual(fm["seasons"], ["6", "7", "8"])
+
+    def test_block_list(self):
+        fm = _parse_frontmatter(
+            self._make("specialties:\n  - building\n  - pranks")
+        )
+        self.assertEqual(fm["specialties"], ["building", "pranks"])
+
+    def test_inline_dict_list(self):
+        fm = _parse_frontmatter(
+            self._make(
+                'subscriber_milestones:\n  - { date: "2019-03", count: "1M" }'
+            )
+        )
+        self.assertIsInstance(fm["subscriber_milestones"], list)
+        self.assertEqual(fm["subscriber_milestones"][0]["count"], "1M")
+
+    def test_no_frontmatter_returns_empty(self):
+        fm = _parse_frontmatter("just some text")
+        self.assertEqual(fm, {})
+
+    def test_missing_closing_fence_returns_empty(self):
+        fm = _parse_frontmatter("---\nname: Grian\n")
+        self.assertEqual(fm, {})
+
+
+# ---------------------------------------------------------------------------
+# _strip_frontmatter
+# ---------------------------------------------------------------------------
+class TestStripFrontmatter(unittest.TestCase):
+    def test_strips_block(self):
+        content = "---\nname: Grian\n---\n\n# Heading\nbody"
+        body = _strip_frontmatter(content)
+        self.assertNotIn("name:", body)
+        self.assertIn("# Heading", body)
+
+    def test_no_frontmatter_returns_content(self):
+        content = "just text"
+        self.assertEqual(_strip_frontmatter(content), content)
+
+
+# ---------------------------------------------------------------------------
+# _extract_section
+# ---------------------------------------------------------------------------
+class TestExtractSection(unittest.TestCase):
+    BODY = "## Overview\nBio text here.\n\n## Notable Builds\nBuild list.\n\n## Teams\nTeam info."
+
+    def test_extracts_first_section(self):
+        result = _extract_section(self.BODY, "Overview")
+        self.assertIn("Bio text", result)
+        self.assertNotIn("Build list", result)
+
+    def test_extracts_middle_section(self):
+        result = _extract_section(self.BODY, "Notable Builds")
+        self.assertIn("Build list", result)
+
+    def test_missing_section_returns_empty(self):
+        result = _extract_section(self.BODY, "NonExistent")
+        self.assertEqual(result, "")
+
+    def test_case_insensitive(self):
+        result = _extract_section(self.BODY, "overview")
+        self.assertIn("Bio text", result)
+
+
+# ---------------------------------------------------------------------------
+# _first_paragraph
+# ---------------------------------------------------------------------------
+class TestFirstParagraph(unittest.TestCase):
+    def test_returns_first_paragraph(self):
+        text = "First paragraph text.\n\nSecond paragraph."
+        self.assertEqual(_first_paragraph(text), "First paragraph text.")
+
+    def test_skips_headings(self):
+        text = "# Heading\n\nActual paragraph."
+        self.assertEqual(_first_paragraph(text), "Actual paragraph.")
+
+    def test_strips_bold(self):
+        text = "He is **famous** for builds."
+        result = _first_paragraph(text)
+        self.assertNotIn("**", result)
+        self.assertIn("famous", result)
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(_first_paragraph(""), "")
+
+
+# ---------------------------------------------------------------------------
+# _extract_build_bullets
+# ---------------------------------------------------------------------------
+class TestExtractBuildBullets(unittest.TestCase):
+    RAW = (
+        "- **Decked Out (Season 7):** A dungeon crawler game.\n"
+        "- **Decked Out 2 (Season 9):** The sequel.\n"
+        "Some non-bullet text.\n"
+    )
+
+    def test_extracts_two_bullets(self):
+        results = _extract_build_bullets(self.RAW)
+        self.assertEqual(len(results), 2)
+
+    def test_title_parsed(self):
+        results = _extract_build_bullets(self.RAW)
+        self.assertIn("Decked Out (Season 7)", results[0]["title"])
+
+    def test_description_parsed(self):
+        results = _extract_build_bullets(self.RAW)
+        self.assertIn("dungeon", results[0]["description"])
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(_extract_build_bullets(""), [])
+
+
+# ---------------------------------------------------------------------------
+# list_hermits
+# ---------------------------------------------------------------------------
+class TestListHermits(unittest.TestCase):
+    def test_returns_list(self):
+        hermits = list_hermits()
+        self.assertIsInstance(hermits, list)
+
+    def test_each_has_handle_and_name(self):
+        for h in list_hermits():
+            self.assertIn("handle", h)
+            self.assertIn("name", h)
+
+    def test_grian_present(self):
+        handles = [h["handle"] for h in list_hermits()]
+        self.assertIn("grian", handles)
+
+    def test_readme_excluded(self):
+        handles = [h["handle"] for h in list_hermits()]
+        self.assertNotIn("README", handles)
+
+    def test_count_matches_files(self):
+        expected = len([p for p in HERMITS_DIR.glob("*.md") if p.name != "README.md"])
+        self.assertEqual(len(list_hermits()), expected)
+
+
+# ---------------------------------------------------------------------------
+# find_hermit_file
+# ---------------------------------------------------------------------------
+class TestFindHermitFile(unittest.TestCase):
+    def test_exact_handle(self):
+        path = find_hermit_file("grian")
+        self.assertIsNotNone(path)
+        self.assertEqual(path.stem, "grian")
+
+    def test_case_insensitive(self):
+        path = find_hermit_file("GRIAN")
+        self.assertIsNotNone(path)
+
+    def test_partial_handle(self):
+        path = find_hermit_file("tango")
+        self.assertIsNotNone(path)
+        self.assertIn("tangotek", path.stem)
+
+    def test_spaced_name(self):
+        path = find_hermit_file("mumbo jumbo")
+        self.assertIsNotNone(path)
+
+    def test_hyphenated_handle(self):
+        path = find_hermit_file("mumbo-jumbo")
+        self.assertIsNotNone(path)
+
+    def test_not_found_returns_none(self):
+        path = find_hermit_file("nonexistent_xyz_999")
+        self.assertIsNone(path)
+
+    def test_tangotek_by_full_name(self):
+        path = find_hermit_file("TangoTek")
+        self.assertIsNotNone(path)
+
+
+# ---------------------------------------------------------------------------
+# load_profile
+# ---------------------------------------------------------------------------
+class TestLoadProfile(unittest.TestCase):
+    def setUp(self):
+        self.grian_path = find_hermit_file("grian")
+        self.profile = load_profile(self.grian_path)
+
+    def test_name_parsed(self):
+        self.assertEqual(self.profile["name"], "Grian")
+
+    def test_handle_is_stem(self):
+        self.assertEqual(self.profile["handle"], "grian")
+
+    def test_seasons_are_ints(self):
+        for s in self.profile["seasons"]:
+            self.assertIsInstance(s, int)
+
+    def test_grian_in_season_6(self):
+        self.assertIn(6, self.profile["seasons"])
+
+    def test_specialties_list(self):
+        self.assertIsInstance(self.profile["specialties"], list)
+        self.assertGreater(len(self.profile["specialties"]), 0)
+
+    def test_subscriber_milestones_list(self):
+        self.assertIsInstance(self.profile["subscriber_milestones"], list)
+
+    def test_milestone_has_date_and_count(self):
+        for m in self.profile["subscriber_milestones"]:
+            self.assertIn("date", m)
+            self.assertIn("count", m)
+
+    def test_bio_non_empty(self):
+        self.assertGreater(len(self.profile["bio"]), 10)
+
+    def test_status_active(self):
+        self.assertEqual(self.profile["status"], "active")
+
+    def test_joined_season_int(self):
+        self.assertIsInstance(self.profile["joined_season"], int)
+
+
+# ---------------------------------------------------------------------------
+# load_hermit_events
+# ---------------------------------------------------------------------------
+class TestLoadHermitEvents(unittest.TestCase):
+    def test_grian_has_events(self):
+        events = load_hermit_events("Grian")
+        self.assertGreater(len(events), 0)
+
+    def test_all_events_involve_grian(self):
+        events = load_hermit_events("Grian")
+        for ev in events:
+            hermits = [h.lower() for h in ev.get("hermits", [])]
+            self.assertIn("grian", hermits)
+
+    def test_season_filter_applied(self):
+        events = load_hermit_events("Grian", season_filter=7)
+        for ev in events:
+            self.assertEqual(ev.get("season"), 7)
+
+    def test_all_events_excluded(self):
+        # Events with hermits == ["All"] should not appear
+        events = load_hermit_events("Grian")
+        for ev in events:
+            self.assertNotEqual(ev.get("hermits"), ["All"])
+
+    def test_case_insensitive(self):
+        lower = load_hermit_events("grian")
+        upper = load_hermit_events("GRIAN")
+        self.assertEqual(len(lower), len(upper))
+
+    def test_sorted_chronologically(self):
+        events = load_hermit_events("Grian")
+        dates = [ev.get("date", "") for ev in events]
+        # All dates should be non-decreasing (as strings in YYYY format)
+        for i in range(1, len(dates)):
+            self.assertGreaterEqual(dates[i][:4], dates[i - 1][:4])
+
+    def test_unknown_hermit_returns_empty(self):
+        events = load_hermit_events("XyzNonExistentHermit999")
+        self.assertEqual(events, [])
+
+    def test_tangotek_decked_out(self):
+        events = load_hermit_events("TangoTek")
+        titles = [ev.get("title", "") for ev in events]
+        self.assertTrue(any("Decked Out" in t for t in titles))
+
+
+# ---------------------------------------------------------------------------
+# build_output
+# ---------------------------------------------------------------------------
+class TestBuildOutput(unittest.TestCase):
+    def setUp(self):
+        path = find_hermit_file("grian")
+        self.profile = load_profile(path)
+        self.events = load_hermit_events("Grian")
+        self.output = build_output(self.profile, self.events)
+
+    def test_has_required_fields(self):
+        for field in ("name", "handle", "seasons", "bio", "events", "event_count"):
+            self.assertIn(field, self.output)
+
+    def test_event_count_matches_events(self):
+        self.assertEqual(self.output["event_count"], len(self.output["events"]))
+
+    def test_season_filter_stored(self):
+        out = build_output(self.profile, self.events, season_filter=7)
+        self.assertEqual(out["season_filter"], 7)
+
+    def test_no_season_filter_key_absent(self):
+        out = build_output(self.profile, self.events)
+        self.assertNotIn("season_filter", out)
+
+
+# ---------------------------------------------------------------------------
+# format_profile_text
+# ---------------------------------------------------------------------------
+class TestFormatProfileText(unittest.TestCase):
+    def setUp(self):
+        path = find_hermit_file("grian")
+        profile = load_profile(path)
+        events = load_hermit_events("Grian")
+        self.output = build_output(profile, events)
+        self.text = format_profile_text(self.output)
+
+    def test_name_in_header(self):
+        self.assertIn("Grian", self.text)
+
+    def test_status_in_header(self):
+        self.assertIn("ACTIVE", self.text)
+
+    def test_seasons_shown(self):
+        self.assertIn("6", self.text)
+
+    def test_specialties_shown(self):
+        self.assertIn("building", self.text)
+
+    def test_bio_section_shown(self):
+        self.assertIn("ABOUT", self.text)
+
+    def test_milestones_section_shown(self):
+        self.assertIn("SUBSCRIBER MILESTONES", self.text)
+
+    def test_events_section_shown(self):
+        self.assertIn("TIMELINE EVENTS", self.text)
+
+    def test_returns_string(self):
+        self.assertIsInstance(self.text, str)
+
+    def test_no_season_events_message(self):
+        path = find_hermit_file("grian")
+        profile = load_profile(path)
+        # Season 1 — Grian wasn't in season 1
+        events = load_hermit_events("Grian", season_filter=1)
+        out = build_output(profile, events, season_filter=1)
+        text = format_profile_text(out)
+        self.assertIn("No recorded events", text)
+
+
+# ---------------------------------------------------------------------------
+# Data integrity
+# ---------------------------------------------------------------------------
+class TestDataIntegrity(unittest.TestCase):
+    def test_hermits_dir_exists(self):
+        self.assertTrue(HERMITS_DIR.exists())
+
+    def test_events_file_exists(self):
+        self.assertTrue(EVENTS_FILE.exists())
+
+    def test_video_events_file_exists(self):
+        self.assertTrue(VIDEO_EVENTS_FILE.exists())
+
+    def test_all_profiles_parseable(self):
+        for path in HERMITS_DIR.glob("*.md"):
+            if path.name == "README.md":
+                continue
+            try:
+                load_profile(path)
+            except Exception as e:
+                self.fail(f"load_profile({path.name}) raised {e}")
+
+    def test_all_profiles_have_seasons(self):
+        for path in HERMITS_DIR.glob("*.md"):
+            if path.name == "README.md":
+                continue
+            p = load_profile(path)
+            self.assertIsInstance(p["seasons"], list, f"{path.name} missing seasons")
+
+    def test_all_profiles_have_name(self):
+        for path in HERMITS_DIR.glob("*.md"):
+            if path.name == "README.md":
+                continue
+            p = load_profile(path)
+            self.assertTrue(p["name"], f"{path.name} has empty name")
+
+    def test_all_profiles_have_status(self):
+        for path in HERMITS_DIR.glob("*.md"):
+            if path.name == "README.md":
+                continue
+            p = load_profile(path)
+            self.assertIn(p["status"], {"active", "inactive", "unknown"})
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+class TestCLI(unittest.TestCase):
+    def _run(self, args: list[str]) -> tuple[int, str, str]:
+        """Run main(args) and capture stdout/stderr."""
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = main(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_hermit_grian_exits_0(self):
+        rc, _, _ = self._run(["--hermit", "Grian"])
+        self.assertEqual(rc, 0)
+
+    def test_hermit_grian_text_contains_name(self):
+        _, out, _ = self._run(["--hermit", "Grian"])
+        self.assertIn("Grian", out)
+
+    def test_hermit_grian_json_valid(self):
+        rc, out, _ = self._run(["--hermit", "Grian", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertEqual(data["name"], "Grian")
+
+    def test_json_has_event_count(self):
+        _, out, _ = self._run(["--hermit", "Grian", "--json"])
+        data = json.loads(out)
+        self.assertIn("event_count", data)
+        self.assertGreater(data["event_count"], 0)
+
+    def test_json_has_seasons(self):
+        _, out, _ = self._run(["--hermit", "Grian", "--json"])
+        data = json.loads(out)
+        self.assertIsInstance(data["seasons"], list)
+
+    def test_season_filter_applied(self):
+        _, out, _ = self._run(["--hermit", "TangoTek", "--season", "7", "--json"])
+        data = json.loads(out)
+        for ev in data["events"]:
+            self.assertEqual(ev["season"], 7)
+
+    def test_season_stored_in_json(self):
+        _, out, _ = self._run(["--hermit", "Grian", "--season", "8", "--json"])
+        data = json.loads(out)
+        self.assertEqual(data.get("season_filter"), 8)
+
+    def test_not_found_exits_1(self):
+        rc, _, err = self._run(["--hermit", "xyz_nobody_999"])
+        self.assertEqual(rc, 1)
+        self.assertIn("No profile found", err)
+
+    def test_list_exits_0(self):
+        rc, _, _ = self._run(["--list"])
+        self.assertEqual(rc, 0)
+
+    def test_list_contains_grian(self):
+        _, out, _ = self._run(["--list"])
+        self.assertIn("grian", out)
+
+    def test_list_json_returns_list(self):
+        _, out, _ = self._run(["--list", "--json"])
+        data = json.loads(out)
+        self.assertIsInstance(data, list)
+
+    def test_list_json_has_handle_and_name(self):
+        _, out, _ = self._run(["--list", "--json"])
+        data = json.loads(out)
+        for item in data:
+            self.assertIn("handle", item)
+            self.assertIn("name", item)
+
+    def test_partial_name_match(self):
+        rc, out, _ = self._run(["--hermit", "tango"])
+        self.assertEqual(rc, 0)
+        self.assertIn("TangoTek", out)
+
+    def test_case_insensitive_match(self):
+        rc, _, _ = self._run(["--hermit", "GRIAN"])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/hermit_profile.py
+++ b/tools/hermit_profile.py
@@ -1,0 +1,517 @@
+"""
+tools/hermit_profile.py — Hermit biography lookup CLI.
+
+Returns a full biography for a named Hermit drawn from the knowledge base:
+join date, active seasons, specialties, subscriber milestones, bio paragraph,
+notable builds, teams, and related timeline events.
+
+Usage:
+    python -m tools.hermit_profile --hermit Grian
+    python -m tools.hermit_profile --hermit tangotek --json
+    python -m tools.hermit_profile --hermit "mumbo jumbo" --season 7
+    python -m tools.hermit_profile --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+HERMITS_DIR = Path(__file__).parent.parent / "knowledge" / "hermits"
+EVENTS_FILE = (
+    Path(__file__).parent.parent / "knowledge" / "timelines" / "events.json"
+)
+VIDEO_EVENTS_FILE = (
+    Path(__file__).parent.parent / "knowledge" / "timelines" / "video_events.json"
+)
+
+# ---------------------------------------------------------------------------
+# Frontmatter / markdown helpers
+# ---------------------------------------------------------------------------
+
+def _parse_frontmatter(content: str) -> dict:
+    """Lightweight YAML frontmatter parser (handles str, list, inline-dict, int)."""
+    result: dict = {}
+    if not content.startswith("---"):
+        return result
+    end = content.find("\n---", 3)
+    if end == -1:
+        return result
+    block = content[3:end].strip()
+    # Handle inline list items: key: [a, b, c]
+    # Handle block list items starting with "  -"
+    current_key: str | None = None
+    current_list: list | None = None
+    for raw_line in block.splitlines():
+        line = raw_line.rstrip()
+        # Block list continuation
+        if current_list is not None and re.match(r"^\s+-\s+", line):
+            item_raw = re.sub(r"^\s+-\s+", "", line).strip()
+            # Inline dict: { key: val, key: val }
+            if item_raw.startswith("{") and item_raw.endswith("}"):
+                inner = item_raw[1:-1]
+                d: dict = {}
+                for part in inner.split(","):
+                    part = part.strip()
+                    if ":" in part:
+                        k, v = part.split(":", 1)
+                        d[k.strip()] = v.strip().strip('"')
+                current_list.append(d)
+            else:
+                current_list.append(item_raw.strip('"').strip("'"))
+            continue
+        # New key
+        if ":" in line and not line.startswith(" "):
+            # Flush previous list
+            if current_list is not None and current_key is not None:
+                result[current_key] = current_list
+                current_list = None
+                current_key = None
+            key, _, val = line.partition(":")
+            key = key.strip()
+            val = val.strip()
+            if val == "":
+                # Possibly a block list follows
+                current_key = key
+                current_list = []
+            elif val.startswith("[") and val.endswith("]"):
+                # Inline list
+                inner = val[1:-1]
+                result[key] = [
+                    token.strip().strip('"').strip("'")
+                    for token in inner.split(",")
+                    if token.strip()
+                ]
+            else:
+                # Scalar
+                cleaned = val.strip('"').strip("'")
+                # Try int
+                try:
+                    result[key] = int(cleaned)
+                except ValueError:
+                    result[key] = cleaned
+    # Flush trailing list
+    if current_list is not None and current_key is not None:
+        result[current_key] = current_list
+    return result
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Return markdown body without the leading --- block."""
+    if not content.startswith("---"):
+        return content
+    end = content.find("\n---", 3)
+    if end == -1:
+        return content
+    return content[end + 4:].lstrip("\n")
+
+
+def _extract_section(body: str, heading: str) -> str:
+    """
+    Extract the text content of a ## Heading section.
+    Returns everything from that heading up to (but not including) the next ## heading.
+    """
+    pattern = re.compile(
+        r"^##\s+" + re.escape(heading) + r"\s*$", re.MULTILINE | re.IGNORECASE
+    )
+    m = pattern.search(body)
+    if not m:
+        return ""
+    start = m.end()
+    # Find next ## heading
+    next_h = re.search(r"^##\s+", body[start:], re.MULTILINE)
+    end = start + next_h.start() if next_h else len(body)
+    return body[start:end].strip()
+
+
+def _first_paragraph(text: str) -> str:
+    """Return the first non-empty paragraph from a markdown block."""
+    for para in text.split("\n\n"):
+        clean = para.strip()
+        if clean and not clean.startswith("#"):
+            # Strip markdown bold/italic markers
+            clean = re.sub(r"\*\*(.+?)\*\*", r"\1", clean)
+            clean = re.sub(r"\*(.+?)\*", r"\1", clean)
+            return clean
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Hermit discovery & loading
+# ---------------------------------------------------------------------------
+
+def list_hermits() -> list[dict]:
+    """Return [{handle, name}] for every hermit profile file (sorted by handle)."""
+    results = []
+    for path in sorted(HERMITS_DIR.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        content = path.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        results.append(
+            {
+                "handle": path.stem,
+                "name": fm.get("name", path.stem),
+                "status": fm.get("status", "unknown"),
+            }
+        )
+    return results
+
+
+def _normalise(s: str) -> str:
+    """Lowercase, strip spaces and hyphens for fuzzy comparison."""
+    return re.sub(r"[\s\-_]+", "", s.lower())
+
+
+def find_hermit_file(query: str) -> Path | None:
+    """
+    Find the hermit profile file best matching the query.
+
+    Matching order (first match wins):
+    1. Exact handle match (e.g. "grian" → grian.md)
+    2. Exact name match from frontmatter
+    3. Handle contains the normalised query
+    4. Normalised name contains the normalised query
+    """
+    norm_query = _normalise(query)
+    candidates: list[tuple[int, Path]] = []  # (priority, path)
+    for path in HERMITS_DIR.glob("*.md"):
+        if path.name == "README.md":
+            continue
+        content = path.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        handle = _normalise(path.stem)
+        name = _normalise(fm.get("name", ""))
+        if handle == norm_query:
+            candidates.append((0, path))
+        elif name == norm_query:
+            candidates.append((1, path))
+        elif norm_query in handle:
+            candidates.append((2, path))
+        elif norm_query in name:
+            candidates.append((3, path))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0])
+    return candidates[0][1]
+
+
+def load_profile(path: Path) -> dict:
+    """Parse a hermit profile file into a structured dict."""
+    content = path.read_text(encoding="utf-8")
+    fm = _parse_frontmatter(content)
+    body = _strip_frontmatter(content)
+
+    # Coerce seasons to list[int]
+    raw_seasons = fm.get("seasons", [])
+    seasons: list[int] = []
+    for s in raw_seasons:
+        try:
+            seasons.append(int(s))
+        except (ValueError, TypeError):
+            pass
+
+    # Coerce subscriber_milestones
+    milestones = []
+    for m in fm.get("subscriber_milestones", []):
+        if isinstance(m, dict):
+            milestones.append({"date": m.get("date", ""), "count": m.get("count", "")})
+
+    return {
+        "handle": path.stem,
+        "name": fm.get("name", path.stem),
+        "real_name": fm.get("real_name", ""),
+        "youtube": fm.get("youtube", ""),
+        "hermitcraft_page": fm.get("hermitcraft_page", ""),
+        "joined_season": fm.get("joined_season"),
+        "joined_year": fm.get("joined_year"),
+        "join_date": fm.get("join_date", ""),
+        "status": fm.get("status", "unknown"),
+        "nationality": fm.get("nationality", ""),
+        "specialties": fm.get("specialties", []),
+        "seasons": seasons,
+        "subscriber_milestones": milestones,
+        # Markdown sections
+        "bio": _first_paragraph(_extract_section(body, "Overview") or body),
+        "notable_builds": _extract_section(body, "Notable Builds & Projects"),
+        "teams": _extract_section(body, "Teams & Groups"),
+        "trivia": _extract_section(body, "Notable In-Jokes / Trivia"),
+        "raw_body": body,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Event loading
+# ---------------------------------------------------------------------------
+
+def _load_event_files() -> list[dict]:
+    events: list[dict] = []
+    for path in (EVENTS_FILE, VIDEO_EVENTS_FILE):
+        if path.exists():
+            try:
+                events.extend(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                pass
+    return events
+
+
+def load_hermit_events(hermit_name: str, season_filter: int | None = None) -> list[dict]:
+    """
+    Return events from events.json / video_events.json that involve this hermit.
+
+    Matches on the event's `hermits` list (case-insensitive, after normalising).
+    Events with hermits == ["All"] are excluded (too generic).
+    """
+    norm = _normalise(hermit_name)
+    results = []
+    for ev in _load_event_files():
+        hermits = ev.get("hermits", [])
+        if hermits == ["All"]:
+            continue
+        if season_filter is not None and ev.get("season") != season_filter:
+            continue
+        match = any(_normalise(h) == norm for h in hermits)
+        if match:
+            results.append(ev)
+    # Sort chronologically
+    def _sort_key(ev: dict) -> tuple:
+        d = ev.get("date", "")
+        parts = d.split("-")
+        try:
+            return (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0, int(parts[2]) if len(parts) > 2 else 0)
+        except (ValueError, IndexError):
+            return (9999, 0, 0)
+    results.sort(key=_sort_key)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output builders
+# ---------------------------------------------------------------------------
+
+def build_output(
+    profile: dict,
+    events: list[dict],
+    season_filter: int | None = None,
+) -> dict:
+    """Assemble the final output dict from a loaded profile + events."""
+    out: dict = {
+        "handle": profile["handle"],
+        "name": profile["name"],
+        "real_name": profile["real_name"],
+        "status": profile["status"],
+        "nationality": profile["nationality"],
+        "youtube": profile["youtube"],
+        "hermitcraft_page": profile["hermitcraft_page"],
+        "joined_season": profile["joined_season"],
+        "joined_year": profile["joined_year"],
+        "join_date": profile["join_date"],
+        "specialties": profile["specialties"],
+        "seasons": profile["seasons"],
+        "subscriber_milestones": profile["subscriber_milestones"],
+        "bio": profile["bio"],
+        "notable_builds_raw": profile["notable_builds"],
+        "teams_raw": profile["teams"],
+        "trivia_raw": profile["trivia"],
+        "events": events,
+        "event_count": len(events),
+    }
+    if season_filter is not None:
+        out["season_filter"] = season_filter
+    return out
+
+
+_BULLET_RE = re.compile(r"^[\-\*]\s+\*\*(.+?)\*\*[:\s—–-]*(.*)$")
+
+
+def _extract_build_bullets(raw: str) -> list[dict]:
+    """Parse '- **Title:** description' lines from the notable builds section."""
+    results = []
+    for line in raw.splitlines():
+        m = _BULLET_RE.match(line.strip())
+        if m:
+            results.append({"title": m.group(1).strip(), "description": m.group(2).strip()})
+    return results
+
+
+def format_profile_text(output: dict) -> str:
+    """Format the profile output as a human-readable text digest."""
+    lines: list[str] = []
+
+    name = output["name"]
+    status = output["status"].upper()
+    nationality = output["nationality"]
+    joined = f"Season {output['joined_season']}" if output.get("joined_season") else ""
+    joined_year = f" ({output['joined_year']})" if output.get("joined_year") else ""
+    seasons_str = ", ".join(str(s) for s in (output.get("seasons") or []))
+
+    lines.append("=" * 60)
+    lines.append(f"  {name}  [{status}]")
+    lines.append("=" * 60)
+
+    header_parts = []
+    if nationality:
+        header_parts.append(nationality)
+    if joined:
+        header_parts.append(f"Joined {joined}{joined_year}")
+    if seasons_str:
+        header_parts.append(f"Seasons: {seasons_str}")
+    if header_parts:
+        lines.append("  " + " · ".join(header_parts))
+
+    specialties = output.get("specialties") or []
+    if specialties:
+        lines.append(f"  Known for: {', '.join(specialties)}")
+
+    if output.get("real_name"):
+        lines.append(f"  Real name: {output['real_name']}")
+    if output.get("youtube"):
+        lines.append(f"  YouTube: {output['youtube']}")
+
+    lines.append("")
+
+    # Bio
+    if output.get("bio"):
+        lines.append("ABOUT")
+        lines.append("-" * 40)
+        # Word-wrap at ~72 chars
+        bio = output["bio"]
+        words = bio.split()
+        current_line = ""
+        for word in words:
+            if len(current_line) + len(word) + 1 > 72:
+                lines.append(current_line)
+                current_line = word
+            else:
+                current_line = (current_line + " " + word).strip()
+        if current_line:
+            lines.append(current_line)
+        lines.append("")
+
+    # Notable builds
+    builds = _extract_build_bullets(output.get("notable_builds_raw") or "")
+    if builds:
+        lines.append("NOTABLE BUILDS & PROJECTS")
+        lines.append("-" * 40)
+        for b in builds:
+            desc = f" — {b['description']}" if b["description"] else ""
+            lines.append(f"  • {b['title']}{desc}")
+        lines.append("")
+
+    # Subscriber milestones
+    milestones = output.get("subscriber_milestones") or []
+    if milestones:
+        lines.append("SUBSCRIBER MILESTONES")
+        lines.append("-" * 40)
+        for m in milestones:
+            lines.append(f"  • {m['count']}  ({m['date']})")
+        lines.append("")
+
+    # Timeline events
+    events = output.get("events") or []
+    season_filter = output.get("season_filter")
+    if events:
+        header = "TIMELINE EVENTS"
+        if season_filter is not None:
+            header += f" (Season {season_filter})"
+        lines.append(header)
+        lines.append("-" * 40)
+        for ev in events:
+            date = ev.get("date", "unknown date")
+            season = ev.get("season", "?")
+            title = ev.get("title", "(untitled)")
+            ev_type = ev.get("type", "")
+            tag = f"[S{season}·{ev_type}]" if ev_type else f"[S{season}]"
+            lines.append(f"  {date}  {tag}  {title}")
+        lines.append("")
+
+    # Season filter note if no events
+    if season_filter is not None and not events:
+        lines.append(f"  (No recorded events for Season {season_filter})")
+        lines.append("")
+
+    lines.append(f"  hermitcraft_page: {output.get('hermitcraft_page', 'N/A')}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.hermit_profile",
+        description="Look up a Hermit's full profile from the knowledge base.",
+    )
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--hermit",
+        metavar="NAME",
+        help="Hermit name or handle to look up (case-insensitive, partial match ok)",
+    )
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="List all available hermit handles and names",
+    )
+    p.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        help="Restrict timeline events shown to this season number",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON instead of formatted text",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # --list
+    if args.list:
+        hermits = list_hermits()
+        if getattr(args, "json", False):
+            print(json.dumps(hermits, indent=2))
+        else:
+            print(f"{'Handle':<22}  {'Name':<25}  Status")
+            print("-" * 60)
+            for h in hermits:
+                print(f"  {h['handle']:<20}  {h['name']:<25}  {h['status']}")
+        return 0
+
+    # --hermit NAME
+    path = find_hermit_file(args.hermit)
+    if path is None:
+        print(
+            f"[hermit_profile] No profile found for '{args.hermit}'. "
+            f"Use --list to see available hermits.",
+            file=sys.stderr,
+        )
+        return 1
+
+    profile = load_profile(path)
+    events = load_hermit_events(profile["name"], season_filter=args.season)
+    output = build_output(profile, events, season_filter=args.season)
+
+    if args.json:
+        print(json.dumps(output, indent=2))
+    else:
+        print(format_profile_text(output))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/hermit_profile.py` — a structured biography lookup CLI for any of the 27 Hermits in the knowledge base
- Answers the most natural Hermitcraft question: **"Tell me about Grian"** / **"Who is TangoTek?"**
- Fuzzy-matches hermit names case-insensitively (handles partial names, hyphens, spaces: `"tango"`, `"mumbo jumbo"`, `"GRIAN"` all work)
- Pulls together data from three sources: YAML frontmatter (seasons, specialties, milestones), markdown body (bio, notable builds, teams), and `events.json` / `video_events.json` (timeline events)
- 91 unit tests in `tests/test_hermit_profile.py`

## Example usage

```bash
# Full profile for Grian (text output)
python -m tools.hermit_profile --hermit Grian

# TangoTek's Season 7 events only
python -m tools.hermit_profile --hermit tangotek --season 7

# Machine-readable JSON for bot/script consumption
python -m tools.hermit_profile --hermit "mumbo jumbo" --json

# List all available hermit handles
python -m tools.hermit_profile --list
python -m tools.hermit_profile --list --json
```

## Flags

| Flag | Description |
|------|-------------|
| `--hermit NAME` | Case-insensitive partial match against handle or display name |
| `--season N` | Restrict timeline events to one season number |
| `--json` | Output as JSON (includes all structured fields) |
| `--list` | Enumerate all available hermit handles and names |

## Test plan

- [x] 91 unit tests pass: `python3 -m unittest tests.test_hermit_profile -v`
- [x] Covers: frontmatter parsing, section extraction, fuzzy matching, event loading, season filter, output building, text formatting, all CLI flags, data integrity across all 27 profiles
- [x] Smoke-tested: Grian, TangoTek (--season 7), MumboJumbo (--json), --list, not-found exit 1

Closes #83