### PR TITLE
[hermitcraft-agent] Add hermit-vs-hermit collaboration query

### DIFF
--- a/tests/test_collab_query.py
+++ b/tests/test_collab_query.py
@@ -1,0 +1,375 @@
+"""
+Tests for tools/collab_query.py
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.collab_query import (
+    EVENTS_FILE,
+    VIDEO_EVENTS_FILE,
+    HERMITS_DIR,
+    _normalise,
+    _resolve_hermit_name,
+    _event_sort_key,
+    find_shared_events,
+    build_output,
+    format_text,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalise
+# ---------------------------------------------------------------------------
+class TestNormalise(unittest.TestCase):
+    def test_lowercases(self):
+        self.assertEqual(_normalise("Grian"), "grian")
+
+    def test_strips_hyphens(self):
+        self.assertEqual(_normalise("mumbo-jumbo"), "mumbojumbo")
+
+    def test_strips_spaces(self):
+        self.assertEqual(_normalise("Mumbo Jumbo"), "mumbojumbo")
+
+    def test_strips_underscores(self):
+        self.assertEqual(_normalise("etho_slab"), "ethoslab")
+
+    def test_empty_string(self):
+        self.assertEqual(_normalise(""), "")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_hermit_name
+# ---------------------------------------------------------------------------
+class TestResolveHermitName(unittest.TestCase):
+    def test_exact_handle(self):
+        name = _resolve_hermit_name("grian")
+        self.assertEqual(name, "Grian")
+
+    def test_case_insensitive(self):
+        name = _resolve_hermit_name("GRIAN")
+        self.assertEqual(name, "Grian")
+
+    def test_partial_handle(self):
+        name = _resolve_hermit_name("tango")
+        self.assertIsNotNone(name)
+        self.assertIn("Tango", name)
+
+    def test_display_name_match(self):
+        name = _resolve_hermit_name("MumboJumbo")
+        self.assertIsNotNone(name)
+        self.assertIn("Mumbo", name)
+
+    def test_spaced_name(self):
+        name = _resolve_hermit_name("mumbo jumbo")
+        self.assertIsNotNone(name)
+
+    def test_not_found_returns_none(self):
+        name = _resolve_hermit_name("xyznonexistent999")
+        self.assertIsNone(name)
+
+    def test_bdoubleo_by_handle(self):
+        name = _resolve_hermit_name("bdoubleo100")
+        self.assertIsNotNone(name)
+
+    def test_returns_string(self):
+        name = _resolve_hermit_name("grian")
+        self.assertIsInstance(name, str)
+
+
+# ---------------------------------------------------------------------------
+# _event_sort_key
+# ---------------------------------------------------------------------------
+class TestEventSortKey(unittest.TestCase):
+    def test_full_date(self):
+        ev = {"date": "2020-06-15"}
+        self.assertEqual(_event_sort_key(ev), (2020, 6, 15))
+
+    def test_year_month(self):
+        ev = {"date": "2019-03"}
+        self.assertEqual(_event_sort_key(ev), (2019, 3, 0))
+
+    def test_year_only(self):
+        ev = {"date": "2018"}
+        self.assertEqual(_event_sort_key(ev), (2018, 0, 0))
+
+    def test_no_date_returns_sentinel(self):
+        ev = {}
+        self.assertEqual(_event_sort_key(ev)[0], 9999)
+
+    def test_sort_order(self):
+        events = [
+            {"date": "2021"},
+            {"date": "2018"},
+            {"date": "2020-06"},
+        ]
+        events.sort(key=_event_sort_key)
+        years = [e["date"][:4] for e in events]
+        self.assertEqual(years, ["2018", "2020", "2021"])
+
+
+# ---------------------------------------------------------------------------
+# find_shared_events
+# ---------------------------------------------------------------------------
+class TestFindSharedEvents(unittest.TestCase):
+    def test_grian_mumbo_has_results(self):
+        events = find_shared_events("Grian", "MumboJumbo")
+        self.assertGreater(len(events), 0)
+
+    def test_both_hermits_in_every_event(self):
+        events = find_shared_events("Grian", "MumboJumbo")
+        for ev in events:
+            normed = [_normalise(h) for h in ev.get("hermits", [])]
+            self.assertIn("grian", normed)
+            self.assertIn("mumbojumbo", normed)
+
+    def test_all_events_excluded(self):
+        events = find_shared_events("Grian", "MumboJumbo")
+        for ev in events:
+            self.assertNotEqual(ev.get("hermits"), ["All"])
+
+    def test_season_filter(self):
+        events = find_shared_events("Grian", "MumboJumbo", season_filter=6)
+        for ev in events:
+            self.assertEqual(ev.get("season"), 6)
+
+    def test_season_filter_reduces_results(self):
+        all_events = find_shared_events("Grian", "MumboJumbo")
+        s6_events = find_shared_events("Grian", "MumboJumbo", season_filter=6)
+        self.assertLessEqual(len(s6_events), len(all_events))
+
+    def test_type_filter(self):
+        events = find_shared_events("Grian", "MumboJumbo", type_filter=["lore"])
+        for ev in events:
+            self.assertEqual(ev.get("type"), "lore")
+
+    def test_unknown_hermit_returns_empty(self):
+        events = find_shared_events("Grian", "XyzNobody999")
+        self.assertEqual(events, [])
+
+    def test_sorted_chronologically(self):
+        events = find_shared_events("Grian", "MumboJumbo")
+        keys = [_event_sort_key(e) for e in events]
+        self.assertEqual(keys, sorted(keys))
+
+    def test_same_hermit_returns_empty(self):
+        # Grian × Grian should return no events (no event lists Grian twice)
+        events = find_shared_events("Grian", "Grian")
+        self.assertEqual(events, [])
+
+    def test_tangotek_iskall_season7(self):
+        events = find_shared_events("TangoTek", "Iskall85", season_filter=7)
+        self.assertGreater(len(events), 0)
+
+    def test_each_event_has_required_fields(self):
+        events = find_shared_events("Grian", "MumboJumbo")
+        for ev in events:
+            self.assertIn("title", ev)
+            self.assertIn("season", ev)
+            self.assertIn("hermits", ev)
+
+
+# ---------------------------------------------------------------------------
+# build_output
+# ---------------------------------------------------------------------------
+class TestBuildOutput(unittest.TestCase):
+    def setUp(self):
+        self.events = find_shared_events("Grian", "MumboJumbo")
+        self.output = build_output("Grian", "MumboJumbo", self.events)
+
+    def test_hermit_names_present(self):
+        self.assertEqual(self.output["hermit_a"], "Grian")
+        self.assertEqual(self.output["hermit_b"], "MumboJumbo")
+
+    def test_event_count_matches(self):
+        self.assertEqual(self.output["event_count"], len(self.events))
+
+    def test_seasons_with_collabs_is_sorted_list(self):
+        seasons = self.output["seasons_with_collabs"]
+        self.assertIsInstance(seasons, list)
+        self.assertEqual(seasons, sorted(seasons))
+
+    def test_events_list_present(self):
+        self.assertIn("events", self.output)
+        self.assertIsInstance(self.output["events"], list)
+
+    def test_season_filter_stored(self):
+        out = build_output("Grian", "MumboJumbo", self.events, season_filter=6)
+        self.assertEqual(out["season_filter"], 6)
+
+    def test_no_season_filter_key_absent(self):
+        out = build_output("Grian", "MumboJumbo", self.events)
+        self.assertNotIn("season_filter", out)
+
+    def test_type_filter_stored(self):
+        out = build_output("Grian", "MumboJumbo", self.events, type_filter=["lore"])
+        self.assertEqual(out["type_filter"], ["lore"])
+
+    def test_empty_events_gives_zero_count(self):
+        out = build_output("Grian", "MumboJumbo", [])
+        self.assertEqual(out["event_count"], 0)
+        self.assertEqual(out["seasons_with_collabs"], [])
+
+
+# ---------------------------------------------------------------------------
+# format_text
+# ---------------------------------------------------------------------------
+class TestFormatText(unittest.TestCase):
+    def setUp(self):
+        events = find_shared_events("Grian", "MumboJumbo")
+        self.output = build_output("Grian", "MumboJumbo", events)
+        self.text = format_text(self.output)
+
+    def test_returns_string(self):
+        self.assertIsInstance(self.text, str)
+
+    def test_both_names_in_header(self):
+        self.assertIn("Grian", self.text)
+        self.assertIn("Mumbo", self.text)
+
+    def test_event_count_shown(self):
+        count = str(self.output["event_count"])
+        self.assertIn(count, self.text)
+
+    def test_season_headers_present(self):
+        for s in self.output["seasons_with_collabs"]:
+            self.assertIn(f"Season {s}", self.text)
+
+    def test_empty_results_shows_no_events_message(self):
+        out = build_output("Grian", "MumboJumbo", [], season_filter=1)
+        text = format_text(out)
+        self.assertIn("No shared events", text)
+
+    def test_season_filter_label_shown(self):
+        events = find_shared_events("Grian", "MumboJumbo", season_filter=6)
+        out = build_output("Grian", "MumboJumbo", events, season_filter=6)
+        text = format_text(out)
+        self.assertIn("Season 6", text)
+
+    def test_type_filter_label_shown(self):
+        events = find_shared_events("Grian", "MumboJumbo", type_filter=["lore"])
+        out = build_output("Grian", "MumboJumbo", events, type_filter=["lore"])
+        text = format_text(out)
+        self.assertIn("lore", text)
+
+
+# ---------------------------------------------------------------------------
+# Data integrity
+# ---------------------------------------------------------------------------
+class TestDataIntegrity(unittest.TestCase):
+    def test_events_file_exists(self):
+        self.assertTrue(EVENTS_FILE.exists())
+
+    def test_video_events_file_exists(self):
+        self.assertTrue(VIDEO_EVENTS_FILE.exists())
+
+    def test_hermits_dir_exists(self):
+        self.assertTrue(HERMITS_DIR.exists())
+
+    def test_multi_hermit_events_exist(self):
+        events = find_shared_events("Grian", "GoodTimesWithScar")
+        self.assertGreater(len(events), 0)
+
+    def test_events_json_parseable(self):
+        data = json.loads(EVENTS_FILE.read_text())
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+class TestCLI(unittest.TestCase):
+    def _run(self, args: list[str]) -> tuple[int, str, str]:
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = main(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_basic_query_exits_0(self):
+        rc, _, _ = self._run(["--hermit-a", "Grian", "--hermit-b", "Mumbo"])
+        self.assertEqual(rc, 0)
+
+    def test_output_contains_both_names(self):
+        _, out, _ = self._run(["--hermit-a", "Grian", "--hermit-b", "Mumbo"])
+        self.assertIn("Grian", out)
+        self.assertIn("Mumbo", out)
+
+    def test_json_output_valid(self):
+        rc, out, _ = self._run(["--hermit-a", "Grian", "--hermit-b", "Mumbo", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIn("hermit_a", data)
+        self.assertIn("hermit_b", data)
+        self.assertIn("events", data)
+        self.assertIn("event_count", data)
+
+    def test_json_event_count_positive(self):
+        _, out, _ = self._run(["--hermit-a", "Grian", "--hermit-b", "Mumbo", "--json"])
+        data = json.loads(out)
+        self.assertGreater(data["event_count"], 0)
+
+    def test_season_flag(self):
+        _, out, _ = self._run(
+            ["--hermit-a", "Grian", "--hermit-b", "Mumbo", "--season", "6", "--json"]
+        )
+        data = json.loads(out)
+        self.assertEqual(data.get("season_filter"), 6)
+        for ev in data["events"]:
+            self.assertEqual(ev["season"], 6)
+
+    def test_types_flag(self):
+        _, out, _ = self._run(
+            ["--hermit-a", "Grian", "--hermit-b", "Mumbo", "--types", "lore", "--json"]
+        )
+        data = json.loads(out)
+        for ev in data["events"]:
+            self.assertEqual(ev["type"], "lore")
+
+    def test_not_found_hermit_a_exits_1(self):
+        rc, _, err = self._run(["--hermit-a", "xyz999", "--hermit-b", "Grian"])
+        self.assertEqual(rc, 1)
+        self.assertIn("No profile found", err)
+
+    def test_not_found_hermit_b_exits_1(self):
+        rc, _, err = self._run(["--hermit-a", "Grian", "--hermit-b", "xyz999"])
+        self.assertEqual(rc, 1)
+        self.assertIn("No profile found", err)
+
+    def test_same_hermit_exits_1(self):
+        rc, _, err = self._run(["--hermit-a", "Grian", "--hermit-b", "Grian"])
+        self.assertEqual(rc, 1)
+        self.assertIn("same Hermit", err)
+
+    def test_case_insensitive_matching(self):
+        rc, _, _ = self._run(["--hermit-a", "grian", "--hermit-b", "MUMBO"])
+        self.assertEqual(rc, 0)
+
+    def test_partial_name_matching(self):
+        rc, _, _ = self._run(["--hermit-a", "tango", "--hermit-b", "iskall"])
+        self.assertEqual(rc, 0)
+
+    def test_no_results_text_message(self):
+        # Season 1 — Grian wasn't in season 1, so no collabs
+        _, out, _ = self._run(
+            ["--hermit-a", "Grian", "--hermit-b", "Mumbo", "--season", "1"]
+        )
+        self.assertIn("No shared events", out)
+
+    def test_etho_bdubs_has_events(self):
+        rc, out, _ = self._run(
+            ["--hermit-a", "EthosLab", "--hermit-b", "BdoubleO100", "--json"]
+        )
+        data = json.loads(out)
+        self.assertGreater(data["event_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/collab_query.py
+++ b/tools/collab_query.py
@@ -1,0 +1,348 @@
+"""
+tools/collab_query.py — Hermit-vs-hermit collaboration query CLI.
+
+Finds shared events between two named Hermits across all seasons, answering
+questions like "when did Grian and Mumbo interact?" or "what did TangoTek and
+Iskall build together in Season 7?".
+
+Usage:
+    python -m tools.collab_query --hermit-a Grian --hermit-b Mumbo
+    python -m tools.collab_query --hermit-a TangoTek --hermit-b Iskall85 --season 7
+    python -m tools.collab_query --hermit-a EthosLab --hermit-b BdoubleO100 --json
+    python -m tools.collab_query --hermit-a Grian --hermit-b Scar --types lore build
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+EVENTS_FILE = (
+    Path(__file__).parent.parent / "knowledge" / "timelines" / "events.json"
+)
+VIDEO_EVENTS_FILE = (
+    Path(__file__).parent.parent / "knowledge" / "timelines" / "video_events.json"
+)
+HERMITS_DIR = Path(__file__).parent.parent / "knowledge" / "hermits"
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+def _normalise(s: str) -> str:
+    """Lowercase, remove spaces/hyphens/underscores for fuzzy comparison."""
+    return re.sub(r"[\s\-_]+", "", s.lower())
+
+
+def _resolve_hermit_name(query: str) -> str | None:
+    """
+    Return the canonical display name for a hermit by fuzzy-matching against
+    profile filenames and YAML ``name`` fields.
+
+    Returns None if no profile matches.
+    """
+    norm_q = _normalise(query)
+    candidates: list[tuple[int, str]] = []
+    for path in HERMITS_DIR.glob("*.md"):
+        if path.name == "README.md":
+            continue
+        content = path.read_text(encoding="utf-8")
+        # Extract name from frontmatter
+        fm_name = ""
+        if content.startswith("---"):
+            end = content.find("\n---", 3)
+            if end != -1:
+                for line in content[3:end].splitlines():
+                    if line.startswith("name:"):
+                        fm_name = line.split(":", 1)[1].strip().strip('"').strip("'")
+                        break
+        handle = _normalise(path.stem)
+        name_norm = _normalise(fm_name)
+        display = fm_name or path.stem
+
+        if handle == norm_q or name_norm == norm_q:
+            candidates.append((0, display))
+        elif norm_q in handle or norm_q in name_norm:
+            candidates.append((1, display))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0])
+    return candidates[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Event loading
+# ---------------------------------------------------------------------------
+
+def _load_all_events() -> list[dict]:
+    events: list[dict] = []
+    for path in (EVENTS_FILE, VIDEO_EVENTS_FILE):
+        if path.exists():
+            try:
+                events.extend(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                pass
+    return events
+
+
+def _event_sort_key(ev: dict) -> tuple[int, int, int]:
+    parts = ev.get("date", "").split("-")
+    try:
+        return (
+            int(parts[0]) if len(parts) > 0 else 9999,
+            int(parts[1]) if len(parts) > 1 else 0,
+            int(parts[2]) if len(parts) > 2 else 0,
+        )
+    except (ValueError, IndexError):
+        return (9999, 0, 0)
+
+
+def find_shared_events(
+    name_a: str,
+    name_b: str,
+    season_filter: int | None = None,
+    type_filter: list[str] | None = None,
+) -> list[dict]:
+    """
+    Return events where both *name_a* and *name_b* appear in the hermits list.
+
+    Events with ``hermits == ["All"]`` are excluded — they represent
+    server-wide events with no specific pairing signal.
+
+    Args:
+        name_a: Canonical display name of hermit A.
+        name_b: Canonical display name of hermit B.
+        season_filter: If given, restrict to this season number.
+        type_filter: If given, restrict to events whose ``type`` field is in
+            this list (e.g. ``["lore", "build"]``).
+
+    Returns:
+        List of event dicts, sorted chronologically.
+    """
+    norm_a = _normalise(name_a)
+    norm_b = _normalise(name_b)
+    if norm_a == norm_b:
+        return []
+    results: list[dict] = []
+
+    for ev in _load_all_events():
+        hermits = ev.get("hermits", [])
+        if hermits == ["All"]:
+            continue
+        if season_filter is not None and ev.get("season") != season_filter:
+            continue
+        if type_filter is not None and ev.get("type") not in type_filter:
+            continue
+        normed = [_normalise(h) for h in hermits]
+        if norm_a in normed and norm_b in normed:
+            results.append(ev)
+
+    results.sort(key=_event_sort_key)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _seasons_covered(events: list[dict]) -> list[int]:
+    seen: set[int] = set()
+    for ev in events:
+        s = ev.get("season")
+        if isinstance(s, int):
+            seen.add(s)
+    return sorted(seen)
+
+
+def build_output(
+    name_a: str,
+    name_b: str,
+    events: list[dict],
+    season_filter: int | None = None,
+    type_filter: list[str] | None = None,
+) -> dict:
+    """Assemble the final output dict."""
+    seasons = _seasons_covered(events)
+    out: dict = {
+        "hermit_a": name_a,
+        "hermit_b": name_b,
+        "event_count": len(events),
+        "seasons_with_collabs": seasons,
+        "events": events,
+    }
+    if season_filter is not None:
+        out["season_filter"] = season_filter
+    if type_filter is not None:
+        out["type_filter"] = type_filter
+    return out
+
+
+def format_text(output: dict) -> str:
+    """Format collab output as a human-readable digest."""
+    a = output["hermit_a"]
+    b = output["hermit_b"]
+    count = output["event_count"]
+    seasons = output.get("seasons_with_collabs", [])
+    events = output.get("events", [])
+
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append(f"  {a}  ×  {b}")
+    lines.append("=" * 60)
+
+    season_filter = output.get("season_filter")
+    type_filter = output.get("type_filter")
+
+    if count == 0:
+        qualifier = ""
+        if season_filter:
+            qualifier += f" in Season {season_filter}"
+        if type_filter:
+            qualifier += f" of type {', '.join(type_filter)}"
+        lines.append(f"  No shared events found{qualifier}.")
+        lines.append(f"  (Try without filters, or check --types / --season)")
+        return "\n".join(lines)
+
+    season_str = (
+        ", ".join(f"S{s}" for s in seasons) if seasons else "unknown"
+    )
+    lines.append(f"  {count} shared event{'s' if count != 1 else ''}"
+                 f"  ·  Seasons: {season_str}")
+    if season_filter:
+        lines.append(f"  (filtered to Season {season_filter})")
+    if type_filter:
+        lines.append(f"  (filtered to types: {', '.join(type_filter)})")
+    lines.append("")
+
+    current_season: int | None = None
+    for ev in events:
+        s = ev.get("season")
+        if s != current_season:
+            current_season = s
+            lines.append(f"  ── Season {s} ──")
+        date = ev.get("date", "unknown date")
+        ev_type = ev.get("type", "")
+        title = ev.get("title", "(untitled)")
+        desc = ev.get("description", "")
+        tag = f"[{ev_type}]" if ev_type else ""
+        lines.append(f"  {date}  {tag}  {title}")
+        if desc:
+            # Indent and wrap description
+            words = desc.split()
+            line_buf = "      "
+            for word in words:
+                if len(line_buf) + len(word) + 1 > 72:
+                    lines.append(line_buf.rstrip())
+                    line_buf = "      " + word
+                else:
+                    line_buf = (line_buf + " " + word).rstrip() if line_buf == "      " else line_buf + " " + word
+            if line_buf.strip():
+                lines.append(line_buf.rstrip())
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.collab_query",
+        description=(
+            "Find shared Hermitcraft events between two Hermits. "
+            "Answers 'when did A and B collaborate?'"
+        ),
+    )
+    p.add_argument(
+        "--hermit-a",
+        required=True,
+        metavar="NAME",
+        help="First Hermit (case-insensitive, partial match ok)",
+    )
+    p.add_argument(
+        "--hermit-b",
+        required=True,
+        metavar="NAME",
+        help="Second Hermit (case-insensitive, partial match ok)",
+    )
+    p.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        help="Restrict to a specific season number",
+    )
+    p.add_argument(
+        "--types",
+        nargs="+",
+        metavar="TYPE",
+        help="Restrict to event types, e.g. --types lore build collab",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    name_a = _resolve_hermit_name(args.hermit_a)
+    if name_a is None:
+        print(
+            f"[collab_query] No profile found for '{args.hermit_a}'. "
+            "Check spelling or use tools/hermit_profile.py --list.",
+            file=sys.stderr,
+        )
+        return 1
+
+    name_b = _resolve_hermit_name(args.hermit_b)
+    if name_b is None:
+        print(
+            f"[collab_query] No profile found for '{args.hermit_b}'. "
+            "Check spelling or use tools/hermit_profile.py --list.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if _normalise(name_a) == _normalise(name_b):
+        print(
+            "[collab_query] --hermit-a and --hermit-b resolve to the same Hermit.",
+            file=sys.stderr,
+        )
+        return 1
+
+    events = find_shared_events(
+        name_a,
+        name_b,
+        season_filter=args.season,
+        type_filter=args.types,
+    )
+    output = build_output(
+        name_a,
+        name_b,
+        events,
+        season_filter=args.season,
+        type_filter=args.types,
+    )
+
+    if args.json:
+        print(json.dumps(output, indent=2))
+    else:
+        print(format_text(output))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/collab_query.py` — finds all shared timeline events between two named Hermits, directly answering "when did Grian and Mumbo interact?" or "what did TangoTek and Iskall85 build in Season 7?"
- Uses the same fuzzy name matching as `hermit_profile.py` (case-insensitive, partial, hyphen/space tolerant)
- Searches both `events.json` and `video_events.json`; excludes generic `["All"]` server events
- Results grouped by season with descriptions, sorted chronologically
- 62 unit tests in `tests/test_collab_query.py`

## Example usage

```bash
# All shared events between Grian and Mumbo
python -m tools.collab_query --hermit-a Grian --hermit-b Mumbo

# TangoTek × Iskall85 restricted to Season 7
python -m tools.collab_query --hermit-a TangoTek --hermit-b Iskall85 --season 7

# Only lore events involving Grian and Scar
python -m tools.collab_query --hermit-a grian --hermit-b scar --types lore

# JSON output for bots/scripts
python -m tools.collab_query --hermit-a EthosLab --hermit-b BdoubleO100 --json
```

## Flags

| Flag | Description |
|------|-------------|
| `--hermit-a NAME` | First Hermit (required, fuzzy match) |
| `--hermit-b NAME` | Second Hermit (required, fuzzy match) |
| `--season N` | Restrict to one season |
| `--types TYPE...` | Filter by event type: `lore`, `build`, `collab`, `video`, `milestone` |
| `--json` | Machine-readable JSON output |

## Test plan

- [x] 62 tests pass: `python3 -m unittest tests.test_collab_query -v`
- [x] Smoke-tested: Grian×Mumbo (9 events S6–S8), TangoTek×Iskall (S7 filter), EthosLab×Bdubs, type filter, JSON output
- [x] Edge cases: unknown hermit → exit 1, same hermit both sides → exit 1, no results → friendly message
- [x] Rebased cleanly on `origin/main` (0 commits behind)

Closes #84