### PR TITLE
[hermitcraft-agent] Add --top-collabs leaderboard to collab_query

### DIFF
--- a/tests/test_collab_query.py
+++ b/tests/test_collab_query.py
@@ -594,6 +594,22 @@ class TestCLITopCollabs(unittest.TestCase):
         rc, _, _ = self._run(["--hermit-a", "tango", "--top-collabs"])
         self.assertEqual(rc, 0)
 
+    def test_hermit_b_with_top_collabs_warns(self):
+        # --hermit-b is silently ignored in --top-collabs mode;
+        # a warning should be emitted to stderr.
+        rc, _, err = self._run(
+            ["--hermit-a", "Grian", "--top-collabs", "--hermit-b", "Scar"]
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("--hermit-b", err)
+        self.assertIn("ignored", err)
+
+    def test_hermit_b_absent_no_warning(self):
+        # No spurious warning when --hermit-b is not supplied.
+        rc, _, err = self._run(["--hermit-a", "Grian", "--top-collabs"])
+        self.assertEqual(rc, 0)
+        self.assertNotIn("--hermit-b", err)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/collab_query.py
+++ b/tools/collab_query.py
@@ -360,7 +360,7 @@ def format_top_collabs(
         seasons = entry.get("seasons", [])
         s_str = ", ".join(f"S{s}" for s in seasons) if seasons else ""
         s_part = f"  ({s_str})" if s_str else ""
-        plural = "s" if count != 1 else " "
+        plural = "s" if count != 1 else " "  # space (not "") keeps column alignment
         lines.append(
             f"  {rank:2d}. {hermit:<{col_w}}  "
             f"{count} shared event{plural}{s_part}"
@@ -415,7 +415,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--types",
         nargs="+",
         metavar="TYPE",
-        help="Restrict to event types (pairwise mode only), e.g. --types lore build",
+        help="Restrict to event types, e.g. --types lore build collab",
     )
     p.add_argument(
         "--json",
@@ -443,6 +443,12 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     # ── Top-collabs leaderboard mode ──────────────────────────────────────
+    if args.top_collabs and args.hermit_b is not None:
+        print(
+            "Warning: --hermit-b is ignored in --top-collabs mode",
+            file=sys.stderr,
+        )
+
     if args.top_collabs:
         ranked = find_top_collaborators(
             name_a,


### PR DESCRIPTION
## Summary

- Adds `--top-collabs` flag to `tools/collab_query.py` that ranks all Hermits by shared-event count with a single target Hermit
- `--top N` controls how many results to show (default 10)
- `--season N` composable with `--top-collabs` to filter by season
- `--json` outputs the ranked leaderboard as structured JSON
- Pairwise mode and all existing flags are fully unchanged

## Example output

```
Top collaborators for Grian (all seasons):
   1. MumboJumbo         9 shared events  (S6, S7, S8)
   2. GoodTimesWithScar  6 shared events  (S7, S8, S10, S11)
   3. Iskall85           6 shared events  (S6, S7)
```

Closes #95