### PR TITLE
[hermitcraft-agent] Add season highlights CLI for curated top moments per season

### DIFF
--- a/tests/test_season_highlights.py
+++ b/tests/test_season_highlights.py
@@ -1,0 +1,376 @@
+"""
+Tests for tools/season_highlights.py
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.season_highlights import (
+    KNOWN_SEASONS,
+    EVENTS_FILE,
+    _TYPE_SCORE,
+    significance_score,
+    rank_season_highlights,
+    build_highlights_output,
+    format_highlights_text,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# significance_score
+# ---------------------------------------------------------------------------
+class TestSignificanceScore(unittest.TestCase):
+    """Unit tests for the documented significance scoring formula."""
+
+    def _ev(self, **kwargs) -> dict:
+        base: dict = {
+            "type": "build",
+            "hermits": ["Grian"],
+            "date_precision": "month",
+        }
+        base.update(kwargs)
+        return base
+
+    # Type bonus ------------------------------------------------------------------
+
+    def test_milestone_is_highest_type(self):
+        self.assertEqual(_TYPE_SCORE["milestone"], 10)
+
+    def test_meta_is_lowest_type(self):
+        self.assertEqual(_TYPE_SCORE["meta"], 1)
+
+    def test_type_score_order_is_descending(self):
+        ordered = ["milestone", "lore", "game", "collab", "build", "meta"]
+        scores = [_TYPE_SCORE[t] for t in ordered]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_all_six_types_covered(self):
+        expected = {"milestone", "lore", "game", "collab", "build", "meta"}
+        self.assertEqual(set(_TYPE_SCORE.keys()), expected)
+
+    def test_unknown_type_gives_nonzero_safe_score(self):
+        ev = self._ev(type="xyzunknown")
+        # Should not raise; base is 0
+        self.assertIsInstance(significance_score(ev), int)
+
+    # Hermit-count bonus ----------------------------------------------------------
+
+    def test_all_hermits_bonus_is_positive(self):
+        solo = self._ev(hermits=["Grian"])
+        server = self._ev(hermits=["All"])
+        self.assertGreater(significance_score(server), significance_score(solo))
+
+    def test_four_hermits_bonus_greater_than_pair(self):
+        pair = self._ev(hermits=["A", "B"])
+        quad = self._ev(hermits=["A", "B", "C", "D"])
+        self.assertGreater(significance_score(quad), significance_score(pair))
+
+    def test_pair_bonus_greater_than_solo(self):
+        solo = self._ev(hermits=["Grian"])
+        pair = self._ev(hermits=["Grian", "Mumbo"])
+        self.assertGreater(significance_score(pair), significance_score(solo))
+
+    def test_three_hermits_get_pair_bonus_not_group_bonus(self):
+        pair = self._ev(hermits=["A", "B"])
+        trio = self._ev(hermits=["A", "B", "C"])
+        quad = self._ev(hermits=["A", "B", "C", "D"])
+        self.assertEqual(significance_score(pair), significance_score(trio))
+        self.assertGreater(significance_score(quad), significance_score(trio))
+
+    # Date-precision bonus --------------------------------------------------------
+
+    def test_day_precision_scores_higher_than_month(self):
+        month_ev = self._ev(date_precision="month")
+        day_ev = self._ev(date_precision="day")
+        self.assertGreater(significance_score(day_ev), significance_score(month_ev))
+
+    def test_year_precision_gets_no_bonus(self):
+        year_ev = self._ev(date_precision="year")
+        day_ev = self._ev(date_precision="day")
+        self.assertGreater(significance_score(day_ev), significance_score(year_ev))
+
+    # Maximum achievable score ----------------------------------------------------
+
+    def test_milestone_all_hermits_day_equals_14(self):
+        # 10 (milestone) + 3 (all) + 1 (day) = 14
+        ev = self._ev(type="milestone", hermits=["All"], date_precision="day")
+        self.assertEqual(significance_score(ev), 14)
+
+    def test_returns_int(self):
+        self.assertIsInstance(significance_score(self._ev()), int)
+
+
+# ---------------------------------------------------------------------------
+# rank_season_highlights
+# ---------------------------------------------------------------------------
+class TestRankSeasonHighlights(unittest.TestCase):
+
+    def test_returns_list(self):
+        self.assertIsInstance(rank_season_highlights(6), list)
+
+    def test_season_6_has_highlights(self):
+        self.assertGreater(len(rank_season_highlights(6)), 0)
+
+    def test_each_entry_has_required_keys(self):
+        for entry in rank_season_highlights(6):
+            for key in ("rank", "title", "description", "date",
+                        "type", "hermits", "significance_score"):
+                self.assertIn(key, entry)
+
+    def test_sorted_descending_by_score(self):
+        result = rank_season_highlights(6)
+        scores = [e["significance_score"] for e in result]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_ranks_sequential_from_1(self):
+        result = rank_season_highlights(6, top_n=5)
+        self.assertEqual([e["rank"] for e in result], list(range(1, len(result) + 1)))
+
+    def test_top_n_limits_results(self):
+        self.assertLessEqual(len(rank_season_highlights(6, top_n=3)), 3)
+
+    def test_top_n_1_returns_exactly_1(self):
+        self.assertEqual(len(rank_season_highlights(6, top_n=1)), 1)
+
+    def test_top_result_has_high_score(self):
+        # #1 event should score above the minimum type score (meta=1)
+        result = rank_season_highlights(6, top_n=1)
+        self.assertGreater(result[0]["significance_score"], 4)
+
+    def test_title_is_string(self):
+        for entry in rank_season_highlights(7, top_n=5):
+            self.assertIsInstance(entry["title"], str)
+
+    def test_hermits_is_list(self):
+        for entry in rank_season_highlights(7, top_n=5):
+            self.assertIsInstance(entry["hermits"], list)
+
+    def test_significance_score_matches_function(self):
+        # Cross-check stored score equals what significance_score() would return
+        import json as _j
+        raw_events = _j.loads(EVENTS_FILE.read_text())
+        s6_lookup = {e["title"]: e for e in raw_events if e.get("season") == 6}
+        for entry in rank_season_highlights(6, top_n=5):
+            raw = s6_lookup.get(entry["title"])
+            if raw:
+                self.assertEqual(
+                    entry["significance_score"],
+                    significance_score(raw),
+                )
+
+    def test_unknown_season_returns_empty(self):
+        self.assertEqual(rank_season_highlights(999), [])
+
+    def test_seasons_6_through_9_all_have_results(self):
+        for s in (6, 7, 8, 9):
+            result = rank_season_highlights(s)
+            self.assertGreater(len(result), 0, f"Season {s} returned no highlights")
+
+    def test_default_top_n_is_10(self):
+        result = rank_season_highlights(9)
+        self.assertLessEqual(len(result), 10)
+
+
+# ---------------------------------------------------------------------------
+# build_highlights_output
+# ---------------------------------------------------------------------------
+class TestBuildHighlightsOutput(unittest.TestCase):
+
+    def setUp(self):
+        self.highlights = rank_season_highlights(8, top_n=5)
+        self.output = build_highlights_output(8, self.highlights, 5)
+
+    def test_season_key_correct(self):
+        self.assertEqual(self.output["season"], 8)
+
+    def test_highlight_count_matches_list_length(self):
+        self.assertEqual(self.output["highlight_count"], len(self.highlights))
+
+    def test_top_n_requested_stored(self):
+        self.assertEqual(self.output["top_n_requested"], 5)
+
+    def test_events_key_present(self):
+        self.assertIn("events", self.output)
+        self.assertIsInstance(self.output["events"], list)
+
+    def test_events_is_same_object_as_input(self):
+        self.assertIs(self.output["events"], self.highlights)
+
+    def test_empty_highlights_zero_count(self):
+        out = build_highlights_output(1, [], 10)
+        self.assertEqual(out["highlight_count"], 0)
+        self.assertEqual(out["events"], [])
+
+    def test_output_is_json_serialisable(self):
+        # Should not raise
+        json.dumps(self.output)
+
+
+# ---------------------------------------------------------------------------
+# format_highlights_text
+# ---------------------------------------------------------------------------
+class TestFormatHighlightsText(unittest.TestCase):
+
+    def setUp(self):
+        self.highlights = rank_season_highlights(9, top_n=5)
+        self.text = format_highlights_text(9, self.highlights, 5)
+
+    def test_returns_string(self):
+        self.assertIsInstance(self.text, str)
+
+    def test_season_number_in_header(self):
+        self.assertIn("Season 9", self.text)
+
+    def test_top_n_mentioned(self):
+        self.assertIn("5", self.text)
+
+    def test_rank_numbers_shown(self):
+        for entry in self.highlights:
+            self.assertIn(str(entry["rank"]), self.text)
+
+    def test_event_titles_shown(self):
+        for entry in self.highlights[:3]:
+            self.assertIn(entry["title"], self.text)
+
+    def test_type_tags_shown(self):
+        # At least one [type] bracket should appear
+        self.assertRegex(self.text, r"\[.+\]")
+
+    def test_score_shown(self):
+        self.assertIn("score:", self.text)
+
+    def test_empty_highlights_shows_no_events_message(self):
+        text = format_highlights_text(1, [], 10)
+        self.assertIn("No events found", text)
+
+    def test_empty_still_contains_header(self):
+        text = format_highlights_text(3, [], 10)
+        self.assertIn("Season 3", text)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+class TestCLI(unittest.TestCase):
+
+    def _run(self, args: list[str]) -> tuple[int, str, str]:
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = main(args)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_basic_query_exits_0(self):
+        rc, _, _ = self._run(["--season", "9"])
+        self.assertEqual(rc, 0)
+
+    def test_output_contains_season_number(self):
+        _, out, _ = self._run(["--season", "9"])
+        self.assertIn("9", out)
+
+    def test_json_output_valid(self):
+        rc, out, _ = self._run(["--season", "9", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        for key in ("season", "events", "highlight_count", "top_n_requested"):
+            self.assertIn(key, data)
+
+    def test_json_season_field_correct(self):
+        _, out, _ = self._run(["--season", "6", "--json"])
+        self.assertEqual(json.loads(out)["season"], 6)
+
+    def test_json_events_nonempty_for_active_season(self):
+        _, out, _ = self._run(["--season", "9", "--json"])
+        self.assertGreater(len(json.loads(out)["events"]), 0)
+
+    def test_json_event_has_required_fields(self):
+        _, out, _ = self._run(["--season", "9", "--json"])
+        first = json.loads(out)["events"][0]
+        for key in ("rank", "title", "description", "date"):
+            self.assertIn(key, first)
+
+    def test_json_sorted_descending_by_score(self):
+        _, out, _ = self._run(["--season", "9", "--json"])
+        scores = [e["significance_score"] for e in json.loads(out)["events"]]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_top_flag_limits_results(self):
+        _, out, _ = self._run(["--season", "9", "--top", "3", "--json"])
+        self.assertLessEqual(len(json.loads(out)["events"]), 3)
+
+    def test_top_default_is_10(self):
+        _, out, _ = self._run(["--season", "9", "--json"])
+        self.assertLessEqual(len(json.loads(out)["events"]), 10)
+
+    def test_top_n_stored_in_json(self):
+        _, out, _ = self._run(["--season", "8", "--top", "7", "--json"])
+        self.assertEqual(json.loads(out)["top_n_requested"], 7)
+
+    def test_unknown_season_exits_1(self):
+        rc, _, err = self._run(["--season", "999"])
+        self.assertEqual(rc, 1)
+        self.assertIn("not found", err)
+
+    def test_unknown_season_error_mentions_available_seasons(self):
+        _, _, err = self._run(["--season", "999"])
+        self.assertIn("Available seasons", err)
+
+    def test_unknown_season_error_lists_season_numbers(self):
+        _, _, err = self._run(["--season", "999"])
+        self.assertIn("1", err)
+        self.assertIn("11", err)
+
+    def test_list_flag_exits_0(self):
+        rc, out, _ = self._run(["--list"])
+        self.assertEqual(rc, 0)
+
+    def test_list_shows_all_season_numbers(self):
+        _, out, _ = self._run(["--list"])
+        for s in KNOWN_SEASONS:
+            self.assertIn(str(s), out)
+
+    def test_all_known_seasons_exit_0(self):
+        for s in KNOWN_SEASONS:
+            rc, _, err = self._run(["--season", str(s)])
+            self.assertEqual(rc, 0, f"Season {s} exited non-zero: {err}")
+
+    def test_season_6_highlights_contain_sahara_or_similar(self):
+        # Season 6 is well-documented — should have recognisable build/lore events
+        _, out, _ = self._run(["--season", "6"])
+        # At least one event title should appear in the output
+        self.assertGreater(len(out.strip()), 50)
+
+
+# ---------------------------------------------------------------------------
+# Data integrity
+# ---------------------------------------------------------------------------
+class TestDataIntegrity(unittest.TestCase):
+
+    def test_events_file_exists(self):
+        self.assertTrue(EVENTS_FILE.exists())
+
+    def test_known_seasons_is_1_to_11(self):
+        self.assertEqual(KNOWN_SEASONS, list(range(1, 12)))
+
+    def test_type_score_all_positive(self):
+        for t, s in _TYPE_SCORE.items():
+            self.assertGreater(s, 0, f"Type '{t}' has non-positive score {s}")
+
+    def test_all_event_types_in_data_are_scoreable(self):
+        events = json.loads(EVENTS_FILE.read_text())
+        unknown = {
+            ev.get("type")
+            for ev in events
+            if ev.get("type") and ev.get("type") not in _TYPE_SCORE
+        }
+        self.assertEqual(unknown, set(), f"Unscored event types found: {unknown}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/season_highlights.py
+++ b/tools/season_highlights.py
@@ -1,0 +1,297 @@
+"""
+tools/season_highlights.py — Curated top-moments digest per Hermitcraft season.
+
+Ranks every timeline event for a season by a documented significance score and
+returns the top N as a shareable highlights list — the fastest way for casual
+fans to get the 'best of' a season without reading a full recap.
+
+Significance scoring (fully documented):
+  Type bonus:
+    milestone  +10  (season-defining moments)
+    lore       +8   (major story / roleplay events)
+    game       +7   (server-wide game shows and challenges)
+    collab     +6   (inter-hermit collaborations)
+    build      +5   (notable construction projects)
+    meta       +1   (server metadata — lowest casual-fan interest)
+  Hermit-count bonus:
+    hermits == ["All"]  +3  (server-wide events are broadly significant)
+    4+ named hermits    +2  (large group involvement)
+    2–3 named hermits   +1  (any collaboration)
+  Date-precision bonus:
+    date_precision == "day"  +1  (well-documented events tend to be notable)
+
+Ties in significance score are broken chronologically (earlier events first).
+
+Usage:
+    python -m tools.season_highlights --season 9
+    python -m tools.season_highlights --season 9 --top 5
+    python -m tools.season_highlights --season 9 --json
+    python -m tools.season_highlights --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SEASONS_DIR = Path(__file__).parent.parent / "knowledge" / "seasons"
+EVENTS_FILE = (
+    Path(__file__).parent.parent / "knowledge" / "timelines" / "events.json"
+)
+VIDEO_EVENTS_FILE = (
+    Path(__file__).parent.parent / "knowledge" / "timelines" / "video_events.json"
+)
+
+KNOWN_SEASONS: list[int] = list(range(1, 12))  # seasons 1–11
+
+# ---------------------------------------------------------------------------
+# Significance scoring
+# ---------------------------------------------------------------------------
+
+#: Per-type base scores — higher = more interesting to casual fans.
+_TYPE_SCORE: dict[str, int] = {
+    "milestone": 10,
+    "lore": 8,
+    "game": 7,
+    "collab": 6,
+    "build": 5,
+    "meta": 1,
+}
+
+
+def significance_score(event: dict) -> int:
+    """
+    Compute a significance score for *event*.
+
+    Higher scores indicate events more likely to appear in a 'best of' list
+    for casual Hermitcraft fans.  See module docstring for full breakdown.
+    """
+    score = _TYPE_SCORE.get(event.get("type", ""), 0)
+
+    hermits = event.get("hermits", [])
+    if hermits == ["All"]:
+        score += 3          # server-wide events are broadly significant
+    elif len(hermits) >= 4:
+        score += 2          # large group involvement
+    elif len(hermits) >= 2:
+        score += 1          # any collaboration
+
+    if event.get("date_precision") == "day":
+        score += 1          # well-documented events tend to be more notable
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Event loading
+# ---------------------------------------------------------------------------
+
+def _load_all_events() -> list[dict]:
+    events: list[dict] = []
+    for path in (EVENTS_FILE, VIDEO_EVENTS_FILE):
+        if path.exists():
+            try:
+                events.extend(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                pass
+    return events
+
+
+def _event_sort_key(ev: dict) -> tuple[int, int, int]:
+    parts = ev.get("date", "").split("-")
+    try:
+        return (
+            int(parts[0]) if len(parts) > 0 else 9999,
+            int(parts[1]) if len(parts) > 1 else 0,
+            int(parts[2]) if len(parts) > 2 else 0,
+        )
+    except (ValueError, IndexError):
+        return (9999, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Core ranking
+# ---------------------------------------------------------------------------
+
+def rank_season_highlights(season: int, top_n: int = 10) -> list[dict]:
+    """
+    Return the top *top_n* events for *season*, ranked by significance score.
+
+    Each returned dict contains:
+        rank, title, description, date, type, hermits, significance_score
+
+    Ties in significance score are broken chronologically (earlier first).
+
+    Returns an empty list when the season has no events in the data files.
+    """
+    all_events = _load_all_events()
+    season_events = [ev for ev in all_events if ev.get("season") == season]
+
+    # Annotate with (score, chronological_key) for stable sorting
+    scored = [
+        (significance_score(ev), _event_sort_key(ev), ev)
+        for ev in season_events
+    ]
+    # Highest score first; chronological order breaks ties
+    scored.sort(key=lambda x: (-x[0], x[1]))
+
+    highlights: list[dict] = []
+    for rank, (score, _, ev) in enumerate(scored[:top_n], start=1):
+        highlights.append(
+            {
+                "rank": rank,
+                "title": ev.get("title", "(untitled)"),
+                "description": ev.get("description", ""),
+                "date": ev.get("date", ""),
+                "type": ev.get("type", ""),
+                "hermits": ev.get("hermits", []),
+                "significance_score": score,
+            }
+        )
+    return highlights
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def build_highlights_output(season: int, highlights: list[dict], top_n: int) -> dict:
+    """
+    Assemble the structured output dict.
+
+    Mirrors the shape of ``GET /seasons/:id/highlights``:
+        {season, highlight_count, top_n_requested, events: [...]}
+    """
+    return {
+        "season": season,
+        "highlight_count": len(highlights),
+        "top_n_requested": top_n,
+        "events": highlights,
+    }
+
+
+def format_highlights_text(season: int, highlights: list[dict], top_n: int) -> str:
+    """Format highlights as a human-readable digest."""
+    header = f"Season {season} Highlights  (top {top_n})"
+    lines: list[str] = [header, "=" * len(header), ""]
+
+    if not highlights:
+        lines.append("  No events found for this season.")
+        return "\n".join(lines)
+
+    for entry in highlights:
+        rank = entry["rank"]
+        ev_type = entry.get("type", "")
+        title = entry["title"]
+        date = entry.get("date", "")
+        hermits = entry.get("hermits", [])
+        desc = entry.get("description", "")
+        score = entry.get("significance_score", 0)
+
+        if hermits == ["All"]:
+            hermit_str = "All hermits"
+        else:
+            hermit_str = ", ".join(hermits[:3]) + (" …" if len(hermits) > 3 else "")
+
+        type_tag = f"[{ev_type}]" if ev_type else ""
+        lines.append(f" {rank:2d}. {type_tag}  {title}")
+        lines.append(f"     {date}  ·  {hermit_str}  (score: {score})")
+
+        if desc:
+            words = desc.split()
+            line_buf = "     "
+            for word in words:
+                if len(line_buf) + len(word) + 1 > 72:
+                    lines.append(line_buf.rstrip())
+                    line_buf = "     " + word
+                else:
+                    if line_buf.strip():
+                        line_buf = line_buf + " " + word
+                    else:
+                        line_buf = line_buf + word
+            if line_buf.strip():
+                lines.append(line_buf.rstrip())
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.season_highlights",
+        description=(
+            "Show the top N most significant events for a Hermitcraft season. "
+            "Events are ranked by a documented significance score — see module "
+            "docstring for the full breakdown."
+        ),
+    )
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        help="Season number (1–11)",
+    )
+    group.add_argument(
+        "--list",
+        action="store_true",
+        help="List available season numbers and exit",
+    )
+    p.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        metavar="N",
+        help="How many highlights to return (default: 10)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print("Available seasons:", ", ".join(str(s) for s in KNOWN_SEASONS))
+        return 0
+
+    season = args.season
+    if season not in KNOWN_SEASONS:
+        print(
+            f"[season_highlights] Season {season} not found. "
+            f"Available seasons: {', '.join(str(s) for s in KNOWN_SEASONS)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    highlights = rank_season_highlights(season, top_n=args.top)
+
+    if args.json:
+        print(
+            json.dumps(
+                build_highlights_output(season, highlights, args.top), indent=2
+            )
+        )
+    else:
+        print(format_highlights_text(season, highlights, args.top))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/season_highlights.py` — a new CLI tool that ranks every timeline event for a given Hermitcraft season by a fully-documented significance score and returns the top N as a shareable highlights digest
- Significance scoring formula (documented in module docstring): type base score (`milestone`=10 … `meta`=1) + hermit-count bonus (All=+3, 4+=+2, 2–3=+1) + date-precision bonus (day=+1)
- Supports `--season N`, `--top N`, `--json`, and `--list` flags; exits 1 with a helpful message for unknown seasons
- Adds 64 tests in `tests/test_season_highlights.py` covering scoring logic, ranking, output helpers, CLI, and data integrity

## Test plan
- [x] `python3 -m unittest tests.test_season_highlights -v` — 64 tests, all pass
- [x] `python3 -m tools.season_highlights --season 9` — human-readable output with ranked events
- [x] `python3 -m tools.season_highlights --season 9 --json` — valid JSON with required keys
- [x] `python3 -m tools.season_highlights --season 999` — exits 1 with helpful error listing available seasons
- [x] `python3 -m tools.season_highlights --list` — lists all 11 seasons

Closes #101