### PR TITLE
[hermitcraft-agent] Add Season in Review markdown digest generator

### DIFF
--- a/tests/test_season_digest.py
+++ b/tests/test_season_digest.py
@@ -1,0 +1,580 @@
+"""
+Tests for tools/season_digest.py
+"""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.season_digest import (
+    KNOWN_SEASONS,
+    _significance_score,
+    build_stats,
+    build_highlights,
+    build_peak_moment,
+    build_collaborations,
+    build_arc_summary,
+    build_digest,
+    render_markdown,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(argv: list[str]) -> tuple[int, str, str]:
+    """Run main(argv), capture stdout/stderr, return (rc, out, err)."""
+    out_buf, err_buf = io.StringIO(), io.StringIO()
+    with redirect_stdout(out_buf), redirect_stderr(err_buf):
+        try:
+            rc = main(argv)
+        except SystemExit as exc:
+            rc = int(exc.code) if exc.code is not None else 0
+    return rc, out_buf.getvalue(), err_buf.getvalue()
+
+
+def _make_event(**kwargs) -> dict:
+    """Minimal synthetic event for unit tests.
+
+    Defaults date_precision to "month" so no day-precision bonus (+1) is
+    applied unless a test explicitly passes date_precision="day".
+    """
+    base: dict = {
+        "season": 9,
+        "type": "milestone",
+        "title": "Test Event",
+        "description": "A test event description.",
+        "date": "2022-06-01",
+        "date_precision": "month",
+        "hermits": ["Grian"],
+        "source": "test",
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _significance_score
+# ---------------------------------------------------------------------------
+
+class TestSignificanceScore(unittest.TestCase):
+
+    def test_milestone_scores_highest_type(self):
+        ev = _make_event(type="milestone", hermits=["Grian"])
+        self.assertEqual(_significance_score(ev), 10)
+
+    def test_meta_scores_lowest_type(self):
+        ev = _make_event(type="meta", hermits=["Grian"])
+        self.assertEqual(_significance_score(ev), 1)
+
+    def test_all_hermits_bonus(self):
+        ev = _make_event(type="milestone", hermits=["All"])
+        self.assertEqual(_significance_score(ev), 13)
+
+    def test_four_hermits_bonus(self):
+        ev = _make_event(type="build", hermits=["A", "B", "C", "D"])
+        self.assertEqual(_significance_score(ev), 7)  # 5 + 2
+
+    def test_pair_bonus(self):
+        ev = _make_event(type="build", hermits=["A", "B"])
+        self.assertEqual(_significance_score(ev), 6)  # 5 + 1
+
+    def test_day_precision_bonus(self):
+        ev = _make_event(type="build", hermits=["A"], date_precision="day")
+        self.assertEqual(_significance_score(ev), 6)  # 5 + 1
+
+    def test_max_score_14(self):
+        ev = _make_event(
+            type="milestone", hermits=["All"], date_precision="day"
+        )
+        self.assertEqual(_significance_score(ev), 14)
+
+    def test_unknown_type_returns_int(self):
+        ev = _make_event(type="xyzunknown")
+        self.assertIsInstance(_significance_score(ev), int)
+
+
+# ---------------------------------------------------------------------------
+# build_stats
+# ---------------------------------------------------------------------------
+
+class TestBuildStats(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(hermits=["Grian", "Scar"], type="build", date="2022-03-01"),
+            _make_event(hermits=["Mumbo"], type="milestone", date="2022-06-15"),
+            _make_event(hermits=["All"], type="meta", date="2023-01-10"),
+        ]
+
+    def test_returns_dict(self):
+        self.assertIsInstance(build_stats(9, self._events()), dict)
+
+    def test_season_key(self):
+        self.assertEqual(build_stats(9, self._events())["season"], 9)
+
+    def test_event_count(self):
+        self.assertEqual(build_stats(9, self._events())["event_count"], 3)
+
+    def test_hermit_count_excludes_all(self):
+        stats = build_stats(9, self._events())
+        # Grian, Scar, Mumbo — "All" not counted
+        self.assertEqual(stats["hermit_count"], 3)
+
+    def test_hermits_sorted(self):
+        stats = build_stats(9, self._events())
+        self.assertEqual(stats["hermits"], sorted(stats["hermits"]))
+
+    def test_date_range(self):
+        stats = build_stats(9, self._events())
+        self.assertEqual(stats["date_start"], "2022-03-01")
+        self.assertEqual(stats["date_end"], "2023-01-10")
+
+    def test_type_breakdown_is_dict(self):
+        self.assertIsInstance(build_stats(9, self._events())["type_breakdown"], dict)
+
+    def test_type_breakdown_counts(self):
+        stats = build_stats(9, self._events())
+        bd = stats["type_breakdown"]
+        self.assertEqual(bd.get("build"), 1)
+        self.assertEqual(bd.get("milestone"), 1)
+        self.assertEqual(bd.get("meta"), 1)
+
+    def test_empty_events_no_crash(self):
+        stats = build_stats(9, [])
+        self.assertEqual(stats["event_count"], 0)
+        self.assertIsNone(stats["date_start"])
+        self.assertIsNone(stats["date_end"])
+        self.assertEqual(stats["hermit_count"], 0)
+
+
+# ---------------------------------------------------------------------------
+# build_highlights
+# ---------------------------------------------------------------------------
+
+class TestBuildHighlights(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(type="milestone", hermits=["All"], date_precision="day"),
+            _make_event(type="build", hermits=["A", "B"], title="Build One"),
+            _make_event(type="lore", hermits=["X"], title="Lore Event"),
+            _make_event(type="meta", hermits=["Y"], title="Meta Event"),
+        ]
+
+    def test_returns_list(self):
+        self.assertIsInstance(build_highlights(9, self._events(), 3), list)
+
+    def test_top_n_limits(self):
+        self.assertLessEqual(len(build_highlights(9, self._events(), 2)), 2)
+
+    def test_sorted_desc_by_score(self):
+        results = build_highlights(9, self._events(), 10)
+        scores = [e["significance_score"] for e in results]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_ranks_sequential(self):
+        results = build_highlights(9, self._events(), 4)
+        for i, e in enumerate(results, 1):
+            self.assertEqual(e["rank"], i)
+
+    def test_required_keys(self):
+        required = {"rank", "title", "description", "date", "type",
+                    "hermits", "significance_score"}
+        for entry in build_highlights(9, self._events(), 4):
+            self.assertTrue(required.issubset(entry.keys()))
+
+    def test_empty_events_returns_empty(self):
+        self.assertEqual(build_highlights(9, [], 5), [])
+
+    def test_hermits_is_list(self):
+        for entry in build_highlights(9, self._events(), 4):
+            self.assertIsInstance(entry["hermits"], list)
+
+
+# ---------------------------------------------------------------------------
+# build_peak_moment
+# ---------------------------------------------------------------------------
+
+class TestBuildPeakMoment(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(type="milestone", hermits=["All"], date_precision="day",
+                        title="Top Event"),
+            _make_event(type="build", hermits=["A"], title="Lesser Event"),
+        ]
+
+    def test_returns_dict_or_none(self):
+        result = build_peak_moment(9, self._events())
+        self.assertIsInstance(result, dict)
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(build_peak_moment(9, []))
+
+    def test_highest_scored_is_returned(self):
+        result = build_peak_moment(9, self._events())
+        self.assertEqual(result["title"], "Top Event")
+
+    def test_required_keys(self):
+        required = {"title", "description", "date", "type", "hermits",
+                    "significance_score"}
+        result = build_peak_moment(9, self._events())
+        self.assertTrue(required.issubset(result.keys()))
+
+    def test_no_rank_key(self):
+        result = build_peak_moment(9, self._events())
+        self.assertNotIn("rank", result)
+
+    def test_score_is_int(self):
+        result = build_peak_moment(9, self._events())
+        self.assertIsInstance(result["significance_score"], int)
+
+
+# ---------------------------------------------------------------------------
+# build_collaborations
+# ---------------------------------------------------------------------------
+
+class TestBuildCollaborations(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(hermits=["Grian", "Scar"], title="Collab A"),
+            _make_event(hermits=["Grian", "Scar"], title="Collab B"),
+            _make_event(hermits=["Mumbo", "Grian"], title="Collab C"),
+            _make_event(hermits=["Solo"], title="Solo Event"),
+            _make_event(hermits=["All"], title="Server Event"),
+        ]
+
+    def test_returns_list(self):
+        self.assertIsInstance(build_collaborations(9, self._events(), 3), list)
+
+    def test_top_n_limits(self):
+        self.assertLessEqual(len(build_collaborations(9, self._events(), 2)), 2)
+
+    def test_sorted_by_count_desc(self):
+        results = build_collaborations(9, self._events(), 3)
+        counts = [e["shared_event_count"] for e in results]
+        self.assertEqual(counts, sorted(counts, reverse=True))
+
+    def test_grian_scar_is_top_pair(self):
+        results = build_collaborations(9, self._events(), 3)
+        top = results[0]
+        pair = {top["hermit_a"], top["hermit_b"]}
+        self.assertEqual(pair, {"Grian", "Scar"})
+
+    def test_grian_scar_count_is_2(self):
+        results = build_collaborations(9, self._events(), 3)
+        top = results[0]
+        self.assertEqual(top["shared_event_count"], 2)
+
+    def test_all_excluded_from_pairs(self):
+        results = build_collaborations(9, self._events(), 5)
+        for entry in results:
+            self.assertNotIn("All", [entry["hermit_a"], entry["hermit_b"]])
+
+    def test_solo_events_excluded(self):
+        results = build_collaborations(9, self._events(), 5)
+        for entry in results:
+            self.assertNotEqual(entry["hermit_a"], entry["hermit_b"])
+
+    def test_required_keys(self):
+        required = {"hermit_a", "hermit_b", "shared_event_count", "event_titles"}
+        for entry in build_collaborations(9, self._events(), 3):
+            self.assertTrue(required.issubset(entry.keys()))
+
+    def test_empty_events_returns_empty(self):
+        self.assertEqual(build_collaborations(9, [], 3), [])
+
+    def test_only_solo_events_returns_empty(self):
+        solo = [_make_event(hermits=["Solo"]) for _ in range(5)]
+        self.assertEqual(build_collaborations(9, solo, 3), [])
+
+
+# ---------------------------------------------------------------------------
+# build_arc_summary
+# ---------------------------------------------------------------------------
+
+class TestBuildArcSummary(unittest.TestCase):
+
+    def _stats(self, **kw) -> dict:
+        base = {
+            "season": 9,
+            "hermit_count": 16,
+            "date_start": "2022-03-05",
+            "date_end": "2023-12-20",
+            "type_breakdown": {"milestone": 3, "build": 5},
+        }
+        base.update(kw)
+        return base
+
+    def _highlights(self):
+        return [
+            {
+                "rank": 1, "type": "milestone", "title": "Season 9 Launches",
+                "description": "The server goes live with 26 hermits.",
+                "date": "2022-03-05", "hermits": ["All"], "significance_score": 14,
+            },
+            {
+                "rank": 2, "type": "lore", "title": "Big Lore Thing",
+                "description": "A major roleplay event unfolds.",
+                "date": "2022-07-01", "hermits": ["Grian", "Scar"],
+                "significance_score": 9,
+            },
+        ]
+
+    def test_returns_string(self):
+        self.assertIsInstance(
+            build_arc_summary(9, self._stats(), self._highlights()), str
+        )
+
+    def test_contains_season_number(self):
+        arc = build_arc_summary(9, self._stats(), self._highlights())
+        self.assertIn("9", arc)
+
+    def test_contains_hermit_count(self):
+        arc = build_arc_summary(9, self._stats(), self._highlights())
+        self.assertIn("16", arc)
+
+    def test_contains_date_range(self):
+        arc = build_arc_summary(9, self._stats(), self._highlights())
+        self.assertIn("2022", arc)
+
+    def test_empty_highlights_no_crash(self):
+        arc = build_arc_summary(9, self._stats(), [])
+        self.assertIsInstance(arc, str)
+        self.assertGreater(len(arc), 0)
+
+    def test_no_milestone_falls_back_gracefully(self):
+        highlights = [
+            {
+                "rank": 1, "type": "build", "title": "Big Build",
+                "description": "A huge structure.",
+                "date": "2022-05-01", "hermits": ["Grian"], "significance_score": 5,
+            }
+        ]
+        arc = build_arc_summary(9, self._stats(), highlights)
+        self.assertIsInstance(arc, str)
+        self.assertGreater(len(arc), 0)
+
+    def test_sparse_stats_no_crash(self):
+        sparse = {"season": 1, "hermit_count": 0, "date_start": None,
+                  "date_end": None, "type_breakdown": {}}
+        arc = build_arc_summary(1, sparse, [])
+        self.assertIsInstance(arc, str)
+
+
+# ---------------------------------------------------------------------------
+# build_digest
+# ---------------------------------------------------------------------------
+
+class TestBuildDigest(unittest.TestCase):
+
+    def test_returns_dict(self):
+        self.assertIsInstance(build_digest(9), dict)
+
+    def test_top_level_keys(self):
+        required = {"season", "stats", "highlights", "peak_moment",
+                    "collaborations", "arc_summary"}
+        self.assertTrue(required.issubset(build_digest(9).keys()))
+
+    def test_season_key_correct(self):
+        self.assertEqual(build_digest(9)["season"], 9)
+
+    def test_highlights_respects_top_n(self):
+        self.assertLessEqual(len(build_digest(9, top_n=3)["highlights"]), 3)
+
+    def test_highlights_is_list(self):
+        self.assertIsInstance(build_digest(9)["highlights"], list)
+
+    def test_collaborations_is_list(self):
+        self.assertIsInstance(build_digest(9)["collaborations"], list)
+
+    def test_arc_summary_is_str(self):
+        self.assertIsInstance(build_digest(9)["arc_summary"], str)
+
+    def test_sparse_season_no_crash(self):
+        d = build_digest(1)
+        self.assertEqual(d["season"], 1)
+        self.assertIsInstance(d["stats"], dict)
+
+    def test_json_serialisable(self):
+        serialised = json.dumps(build_digest(9))
+        self.assertIsInstance(serialised, str)
+
+    def test_stats_subkeys_present(self):
+        stats = build_digest(9)["stats"]
+        for key in ("event_count", "hermit_count", "date_start", "date_end",
+                    "type_breakdown"):
+            self.assertIn(key, stats)
+
+    def test_collaborations_top_pairs_respected(self):
+        d = build_digest(9, top_pairs=2)
+        self.assertLessEqual(len(d["collaborations"]), 2)
+
+
+# ---------------------------------------------------------------------------
+# render_markdown
+# ---------------------------------------------------------------------------
+
+class TestRenderMarkdown(unittest.TestCase):
+
+    def _digest(self):
+        return build_digest(9, top_n=3)
+
+    def test_returns_string(self):
+        self.assertIsInstance(render_markdown(self._digest()), str)
+
+    def test_has_h1_title(self):
+        md = render_markdown(self._digest())
+        self.assertRegex(md, r"^# Hermitcraft Season 9")
+
+    def test_has_quick_stats_section(self):
+        self.assertIn("## Quick Stats", render_markdown(self._digest()))
+
+    def test_has_peak_moment_section(self):
+        self.assertIn("## Peak Moment", render_markdown(self._digest()))
+
+    def test_has_highlights_section(self):
+        self.assertIn("## Top", render_markdown(self._digest()))
+
+    def test_has_collaborations_section(self):
+        self.assertIn("## Notable Collaborations", render_markdown(self._digest()))
+
+    def test_has_arc_section(self):
+        self.assertIn("## Season Arc", render_markdown(self._digest()))
+
+    def test_date_range_present(self):
+        md = render_markdown(self._digest())
+        self.assertIn("Date range", md)
+
+    def test_hermit_count_present(self):
+        md = render_markdown(self._digest())
+        self.assertIn("Hermits", md)
+
+    def test_peak_moment_title_in_output(self):
+        digest = self._digest()
+        peak_title = digest["peak_moment"]["title"]
+        self.assertIn(peak_title, render_markdown(digest))
+
+    def test_no_peak_moment_no_crash(self):
+        digest = self._digest()
+        digest["peak_moment"] = None
+        md = render_markdown(digest)
+        self.assertIsInstance(md, str)
+        self.assertIn("Peak Moment", md)
+
+    def test_empty_highlights_no_crash(self):
+        digest = self._digest()
+        digest["highlights"] = []
+        md = render_markdown(digest)
+        self.assertIsInstance(md, str)
+
+    def test_empty_collabs_no_crash(self):
+        digest = self._digest()
+        digest["collaborations"] = []
+        md = render_markdown(digest)
+        self.assertIsInstance(md, str)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCLI(unittest.TestCase):
+
+    def test_season_exits_0(self):
+        rc, _, _ = _run(["--season", "9"])
+        self.assertEqual(rc, 0)
+
+    def test_list_exits_0(self):
+        rc, out, _ = _run(["--list"])
+        self.assertEqual(rc, 0)
+        self.assertIn("1", out)
+        self.assertIn("11", out)
+
+    def test_unknown_season_exits_1(self):
+        rc, _, err = _run(["--season", "999"])
+        self.assertEqual(rc, 1)
+        self.assertIn("999", err)
+
+    def test_markdown_default_has_h1(self):
+        _, out, _ = _run(["--season", "9"])
+        self.assertRegex(out, r"^# Hermitcraft Season 9")
+
+    def test_markdown_flag_explicit(self):
+        _, out, _ = _run(["--season", "9", "--markdown"])
+        self.assertIn("# Hermitcraft Season 9", out)
+
+    def test_json_flag_valid_json(self):
+        rc, out, _ = _run(["--season", "9", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIsInstance(data, dict)
+
+    def test_json_has_required_keys(self):
+        _, out, _ = _run(["--season", "9", "--json"])
+        data = json.loads(out)
+        for key in ("season", "stats", "highlights", "peak_moment",
+                    "collaborations", "arc_summary"):
+            self.assertIn(key, data)
+
+    def test_json_season_field_correct(self):
+        _, out, _ = _run(["--season", "7", "--json"])
+        data = json.loads(out)
+        self.assertEqual(data["season"], 7)
+
+    def test_top_flag_limits_highlights(self):
+        _, out, _ = _run(["--season", "9", "--json", "--top", "2"])
+        data = json.loads(out)
+        self.assertLessEqual(len(data["highlights"]), 2)
+
+    def test_top_flag_default_is_5(self):
+        _, out, _ = _run(["--season", "9", "--json"])
+        data = json.loads(out)
+        self.assertLessEqual(len(data["highlights"]), 5)
+
+    def test_all_known_seasons_exit_0(self):
+        for s in KNOWN_SEASONS:
+            rc, _, _ = _run(["--season", str(s)])
+            self.assertEqual(rc, 0, f"Season {s} exited nonzero")
+
+    def test_json_and_markdown_mutually_exclusive(self):
+        rc, _, _ = _run(["--season", "9", "--json", "--markdown"])
+        self.assertNotEqual(rc, 0)
+
+    def test_no_args_exits_nonzero(self):
+        rc, _, _ = _run([])
+        self.assertNotEqual(rc, 0)
+
+    def test_json_arc_summary_is_string(self):
+        _, out, _ = _run(["--season", "9", "--json"])
+        data = json.loads(out)
+        self.assertIsInstance(data["arc_summary"], str)
+        self.assertGreater(len(data["arc_summary"]), 0)
+
+    def test_json_stats_has_hermit_count(self):
+        _, out, _ = _run(["--season", "9", "--json"])
+        data = json.loads(out)
+        self.assertGreater(data["stats"]["hermit_count"], 0)
+
+    def test_json_highlights_sorted_by_score(self):
+        _, out, _ = _run(["--season", "9", "--json"])
+        data = json.loads(out)
+        scores = [e["significance_score"] for e in data["highlights"]]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_sparse_season_no_crash(self):
+        rc, _, _ = _run(["--season", "1"])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/season_digest.py
+++ b/tools/season_digest.py
@@ -1,0 +1,535 @@
+"""
+tools/season_digest.py — Shareable "Season in Review" digest generator.
+
+Combines per-season highlights, collaborations, and a narrative arc summary
+into one ready-to-share document.  The markdown output can be pasted directly
+into a Discord message, a Reddit post, or a wiki page; the JSON output feeds
+downstream tools such as a Discord bot or static site generator.
+
+Sections in every digest:
+  1. Quick stats  — date range, hermit count, event-type breakdown
+  2. Top highlights — top N events ranked by significance score, with
+                      contextual prose (title + description)
+  3. Peak moment  — the single highest-scoring event (Hall of Fame entry)
+  4. Notable collaborations — top hermit pairs that teamed up this season
+  5. Season arc   — one-paragraph narrative synthesised from milestone events
+
+Output modes:
+  --markdown  (default)  Ready-to-paste .md document with headers / bullets
+  --json                 Structured dict for downstream tooling
+
+Usage:
+    python -m tools.season_digest --season 9
+    python -m tools.season_digest --season 9 --top 3
+    python -m tools.season_digest --season 9 --json
+    python -m tools.season_digest --season 9 --markdown
+    python -m tools.season_digest --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import itertools
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths / constants
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+_EVENTS_FILE = _REPO_ROOT / "knowledge" / "timelines" / "events.json"
+_VIDEO_EVENTS_FILE = _REPO_ROOT / "knowledge" / "timelines" / "video_events.json"
+
+KNOWN_SEASONS: list[int] = list(range(1, 12))  # seasons 1–11
+
+_DEFAULT_TOP_N = 5
+_DEFAULT_TOP_PAIRS = 3
+
+# ---------------------------------------------------------------------------
+# Significance scoring (mirrors season_highlights / all_time_highlights)
+# ---------------------------------------------------------------------------
+
+_TYPE_SCORE: dict[str, int] = {
+    "milestone": 10,
+    "lore": 8,
+    "game": 7,
+    "collab": 6,
+    "build": 5,
+    "meta": 1,
+}
+
+
+def _significance_score(event: dict) -> int:
+    score = _TYPE_SCORE.get(event.get("type", ""), 0)
+    hermits = event.get("hermits", [])
+    if hermits == ["All"]:
+        score += 3
+    elif len(hermits) >= 4:
+        score += 2
+    elif len(hermits) >= 2:
+        score += 1
+    if event.get("date_precision") == "day":
+        score += 1
+    return score
+
+
+def _event_sort_key(ev: dict) -> tuple[int, int, int]:
+    parts = ev.get("date", "").split("-")
+    try:
+        return (
+            int(parts[0]) if len(parts) > 0 else 9999,
+            int(parts[1]) if len(parts) > 1 else 0,
+            int(parts[2]) if len(parts) > 2 else 0,
+        )
+    except (ValueError, IndexError):
+        return (9999, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Event loading
+# ---------------------------------------------------------------------------
+
+def _load_all_events() -> list[dict]:
+    events: list[dict] = []
+    for path in (_EVENTS_FILE, _VIDEO_EVENTS_FILE):
+        if path.exists():
+            try:
+                events.extend(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                pass
+    return events
+
+
+def _season_events(all_events: list[dict], season: int) -> list[dict]:
+    return [ev for ev in all_events if ev.get("season") == season]
+
+
+# ---------------------------------------------------------------------------
+# Section builders
+# ---------------------------------------------------------------------------
+
+def build_stats(season: int, events: list[dict]) -> dict:
+    """
+    Quick stats block for *season*.
+
+    Returns:
+        season, event_count, hermit_count, hermits, date_start, date_end,
+        type_breakdown (dict of type → count)
+    """
+    if not events:
+        return {
+            "season": season,
+            "event_count": 0,
+            "hermit_count": 0,
+            "hermits": [],
+            "date_start": None,
+            "date_end": None,
+            "type_breakdown": {},
+        }
+
+    hermit_set: set[str] = set()
+    for ev in events:
+        for h in ev.get("hermits", []):
+            if h != "All":
+                hermit_set.add(h)
+
+    dates = sorted(
+        ev.get("date", "")
+        for ev in events
+        if ev.get("date") and ev.get("date_precision") in ("day", "month", "year")
+    )
+    date_start = dates[0] if dates else None
+    date_end = dates[-1] if dates else None
+
+    type_breakdown = dict(
+        collections.Counter(ev.get("type", "unknown") for ev in events)
+    )
+
+    return {
+        "season": season,
+        "event_count": len(events),
+        "hermit_count": len(hermit_set),
+        "hermits": sorted(hermit_set),
+        "date_start": date_start,
+        "date_end": date_end,
+        "type_breakdown": type_breakdown,
+    }
+
+
+def build_highlights(season: int, events: list[dict], top_n: int) -> list[dict]:
+    """
+    Top *top_n* events for *season* ranked by significance score.
+
+    Each entry: rank, title, description, date, type, hermits,
+                significance_score
+    """
+    scored = [
+        (_significance_score(ev), _event_sort_key(ev), ev)
+        for ev in events
+    ]
+    scored.sort(key=lambda x: (-x[0], x[1]))
+
+    results: list[dict] = []
+    for rank, (score, _, ev) in enumerate(scored[:top_n], start=1):
+        results.append(
+            {
+                "rank": rank,
+                "title": ev.get("title", "(untitled)"),
+                "description": ev.get("description", ""),
+                "date": ev.get("date", ""),
+                "type": ev.get("type", ""),
+                "hermits": ev.get("hermits", []),
+                "significance_score": score,
+            }
+        )
+    return results
+
+
+def build_peak_moment(season: int, events: list[dict]) -> dict | None:
+    """
+    The single highest-scoring event for *season* — the Hall of Fame entry.
+
+    Returns None when *events* is empty.
+    Ties broken chronologically (earlier first).
+    """
+    if not events:
+        return None
+
+    best_ev = max(
+        events,
+        key=lambda ev: (_significance_score(ev), tuple(-x for x in _event_sort_key(ev))),
+    )
+    # Re-compute with proper tie-break (max doesn't do compound sort easily)
+    scored = [(_significance_score(ev), _event_sort_key(ev), ev) for ev in events]
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    score, _, best_ev = scored[0]
+
+    return {
+        "title": best_ev.get("title", "(untitled)"),
+        "description": best_ev.get("description", ""),
+        "date": best_ev.get("date", ""),
+        "type": best_ev.get("type", ""),
+        "hermits": best_ev.get("hermits", []),
+        "significance_score": score,
+    }
+
+
+def build_collaborations(season: int, events: list[dict], top_n: int) -> list[dict]:
+    """
+    Top *top_n* hermit pairs by shared-event count for *season*.
+
+    Counts events in which both hermits appear together (excludes "All"
+    catch-all entries, which aren't pair-specific).
+
+    Each entry: hermit_a, hermit_b, shared_event_count, event_titles
+    """
+    # Build per-event hermit sets (named hermits only)
+    named_events = [
+        (ev, set(h for h in ev.get("hermits", []) if h != "All"))
+        for ev in events
+    ]
+
+    pair_events: dict[tuple[str, str], list[str]] = collections.defaultdict(list)
+    for ev, hermit_set in named_events:
+        if len(hermit_set) < 2:
+            continue
+        for a, b in itertools.combinations(sorted(hermit_set), 2):
+            pair_events[(a, b)].append(ev.get("title", "(untitled)"))
+
+    ranked = sorted(
+        pair_events.items(),
+        key=lambda kv: -len(kv[1]),
+    )
+
+    results: list[dict] = []
+    for (a, b), titles in ranked[:top_n]:
+        results.append(
+            {
+                "hermit_a": a,
+                "hermit_b": b,
+                "shared_event_count": len(titles),
+                "event_titles": titles,
+            }
+        )
+    return results
+
+
+def build_arc_summary(season: int, stats: dict, highlights: list[dict]) -> str:
+    """
+    One-paragraph narrative arc synthesised from milestone/lore highlights.
+
+    Pulls thread lines from the top milestone and lore events and weaves
+    them into a human-readable paragraph.  Degrades gracefully: if no
+    milestone events exist, falls back to the top highlights.
+    """
+    # Pick narrative anchor events (milestone > lore > whatever we have)
+    anchors = [h for h in highlights if h.get("type") in ("milestone", "lore")]
+    if not anchors:
+        anchors = highlights[:3]
+
+    if not anchors:
+        return f"Season {season} data is sparse — no narrative arc available."
+
+    hermit_count = stats.get("hermit_count", 0)
+    date_start = stats.get("date_start") or "an unknown date"
+    date_end = stats.get("date_end") or "an unknown date"
+
+    # Opening sentence
+    sentences: list[str] = [
+        f"Season {season} brought together {hermit_count} hermits"
+        f" from {date_start} to {date_end}."
+    ]
+
+    # One sentence per anchor event
+    for anchor in anchors:
+        title = anchor.get("title", "")
+        desc = anchor.get("description", "")
+        # Use first sentence of description if available, else title only
+        first_sentence = desc.split(".")[0].strip() if desc else ""
+        if first_sentence and len(first_sentence) < 200:
+            sentences.append(first_sentence + ".")
+        elif title:
+            sentences.append(f"A defining moment was {title}.")
+
+    # Closing
+    type_breakdown = stats.get("type_breakdown", {})
+    top_type = max(type_breakdown, key=lambda t: type_breakdown[t], default=None)
+    if top_type:
+        sentences.append(
+            f"The season was dominated by {top_type} events,"
+            f" reflecting the server's energy and ambition."
+        )
+
+    return " ".join(sentences)
+
+
+# ---------------------------------------------------------------------------
+# Digest assembler
+# ---------------------------------------------------------------------------
+
+def build_digest(
+    season: int,
+    top_n: int = _DEFAULT_TOP_N,
+    top_pairs: int = _DEFAULT_TOP_PAIRS,
+) -> dict:
+    """
+    Assemble a full Season in Review digest for *season*.
+
+    Returns a structured dict with keys:
+        season, stats, highlights, peak_moment, collaborations, arc_summary
+
+    Never raises for known seasons with sparse data — sections will be empty
+    rather than absent.
+    """
+    all_events = _load_all_events()
+    events = _season_events(all_events, season)
+
+    stats = build_stats(season, events)
+    highlights = build_highlights(season, events, top_n)
+    peak = build_peak_moment(season, events)
+    collabs = build_collaborations(season, events, top_pairs)
+    arc = build_arc_summary(season, stats, highlights)
+
+    return {
+        "season": season,
+        "stats": stats,
+        "highlights": highlights,
+        "peak_moment": peak,
+        "collaborations": collabs,
+        "arc_summary": arc,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown renderer
+# ---------------------------------------------------------------------------
+
+def _md_hermits(hermits: list[str]) -> str:
+    if hermits == ["All"]:
+        return "All hermits"
+    return ", ".join(hermits[:4]) + (" …" if len(hermits) > 4 else "")
+
+
+def render_markdown(digest: dict) -> str:
+    """
+    Render *digest* as a ready-to-paste markdown document.
+    """
+    season = digest["season"]
+    stats = digest.get("stats", {})
+    highlights = digest.get("highlights", [])
+    peak = digest.get("peak_moment")
+    collabs = digest.get("collaborations", [])
+    arc = digest.get("arc_summary", "")
+
+    lines: list[str] = []
+
+    # ── Title ──────────────────────────────────────────────────────────────
+    lines += [f"# Hermitcraft Season {season} — Season in Review", ""]
+
+    # ── Stats ──────────────────────────────────────────────────────────────
+    lines += ["## Quick Stats", ""]
+    date_start = stats.get("date_start") or "unknown"
+    date_end = stats.get("date_end") or "unknown"
+    lines.append(f"- **Date range:** {date_start} → {date_end}")
+    lines.append(f"- **Hermits:** {stats.get('hermit_count', 0)}")
+    lines.append(f"- **Documented events:** {stats.get('event_count', 0)}")
+
+    breakdown = stats.get("type_breakdown", {})
+    if breakdown:
+        bd_str = ", ".join(
+            f"{t}: {c}"
+            for t, c in sorted(breakdown.items(), key=lambda x: -x[1])
+        )
+        lines.append(f"- **Event types:** {bd_str}")
+
+    lines.append("")
+
+    # ── Arc summary ────────────────────────────────────────────────────────
+    lines += ["## Season Arc", "", arc, ""]
+
+    # ── Peak moment ────────────────────────────────────────────────────────
+    lines += ["## Peak Moment", ""]
+    if peak:
+        lines.append(
+            f"**{peak['title']}**  "
+            f"*(score: {peak['significance_score']})*"
+        )
+        if peak.get("date"):
+            lines.append(f"*{peak['date']} · {_md_hermits(peak['hermits'])}*")
+        if peak.get("description"):
+            lines.append("")
+            lines.append(f"> {peak['description']}")
+    else:
+        lines.append("*No peak moment data available for this season.*")
+
+    lines.append("")
+
+    # ── Highlights ─────────────────────────────────────────────────────────
+    lines += [f"## Top {len(highlights)} Highlights", ""]
+    if highlights:
+        for entry in highlights:
+            rank = entry["rank"]
+            title = entry["title"]
+            ev_type = entry.get("type", "")
+            date = entry.get("date", "")
+            desc = entry.get("description", "")
+            score = entry.get("significance_score", 0)
+
+            type_badge = f"`{ev_type}`" if ev_type else ""
+            lines.append(f"### {rank}. {title}")
+            meta_parts = [p for p in [date, _md_hermits(entry.get("hermits", [])),
+                                      f"score: {score}"] if p]
+            lines.append(f"*{' · '.join(meta_parts)}*  {type_badge}")
+            if desc:
+                lines += ["", desc]
+            lines.append("")
+    else:
+        lines.append("*No highlights data available for this season.*")
+        lines.append("")
+
+    # ── Collaborations ─────────────────────────────────────────────────────
+    lines += ["## Notable Collaborations", ""]
+    if collabs:
+        for entry in collabs:
+            a = entry["hermit_a"]
+            b = entry["hermit_b"]
+            count = entry["shared_event_count"]
+            plural = "s" if count != 1 else ""
+            titles = entry.get("event_titles", [])
+            title_str = ", ".join(f"*{t}*" for t in titles[:2])
+            suffix = f" — {title_str}" if title_str else ""
+            lines.append(
+                f"- **{a} & {b}**: {count} shared event{plural}{suffix}"
+            )
+        lines.append("")
+    else:
+        lines.append(
+            "*No multi-hermit collaboration events recorded for this season.*"
+        )
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.season_digest",
+        description=(
+            "Generate a shareable Season in Review digest for a Hermitcraft "
+            "season.  Combines highlights, collaborations, and a narrative arc "
+            "summary into one document."
+        ),
+    )
+    mode_group = p.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        help="Season number (1–11)",
+    )
+    mode_group.add_argument(
+        "--list",
+        action="store_true",
+        help="List available season numbers and exit",
+    )
+    p.add_argument(
+        "--top",
+        type=int,
+        default=_DEFAULT_TOP_N,
+        metavar="N",
+        help=f"Number of highlights to include (default: {_DEFAULT_TOP_N})",
+    )
+
+    fmt_group = p.add_mutually_exclusive_group()
+    fmt_group.add_argument(
+        "--markdown",
+        action="store_true",
+        default=False,
+        help="Output as markdown (default when neither flag is given)",
+    )
+    fmt_group.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Output as JSON",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print("Available seasons:", ", ".join(str(s) for s in KNOWN_SEASONS))
+        return 0
+
+    season = args.season
+    if season not in KNOWN_SEASONS:
+        print(
+            f"[season_digest] Season {season} not found. "
+            f"Available: {', '.join(str(s) for s in KNOWN_SEASONS)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    digest = build_digest(season, top_n=args.top)
+
+    if args.json:
+        print(json.dumps(digest, indent=2))
+    else:
+        # --markdown is default when neither flag is given
+        print(render_markdown(digest))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/season_digest.py` — a shareable Season in Review digest generator that combines per-season highlights, collaborations, and a narrative arc summary into one document
- **Markdown output** (default / `--markdown`): ready-to-paste `.md` with H1 title, Quick Stats, Season Arc, Peak Moment, Top Highlights, and Notable Collaborations sections
- **JSON output** (`--json`): structured dict with all sections machine-readable — feeds downstream tools like Discord bots or static site generators
- Five composable section builders, each independently testable:
  - `build_stats()` — date range, hermit count, event-type breakdown
  - `build_highlights()` — top N events ranked by significance score with contextual prose
  - `build_peak_moment()` — highest-scoring single event (Hall of Fame entry for the season)
  - `build_collaborations()` — top hermit pairs by shared-event count (pair-counting via combinatorics, excludes \"All\" catch-alls)
  - `build_arc_summary()` — one-paragraph narrative synthesised from milestone/lore anchors; degrades gracefully to build/other events when no milestone data exists
- Adds 88 tests in `tests/test_season_digest.py` — all 11 known seasons exit 0 cleanly, including sparse early seasons

## Test plan
- [x] `python3 -m unittest tests.test_season_digest -v` — 88 tests, all pass
- [x] `python3 -m tools.season_digest --season 9` — full markdown digest with all 6 sections
- [x] `python3 -m tools.season_digest --season 9 --json` — valid JSON with `season`, `stats`, `highlights`, `peak_moment`, `collaborations`, `arc_summary`
- [x] `python3 -m tools.season_digest --season 9 --top 3` — highlights capped at 3
- [x] `python3 -m tools.season_digest --season 1` — sparse early season renders without crashing
- [x] `python3 -m tools.season_digest --season 999` — exits 1 with helpful error message
- [x] `python3 -m tools.season_digest --list` — lists all 11 seasons
- [x] `python3 -m tools.season_digest --season 9 --json --markdown` — exits nonzero (mutually exclusive)

Closes #107