### PR TITLE
[hermitcraft-agent] Add --discord embed output to season_digest

### DIFF
--- a/tests/test_season_digest.py
+++ b/tests/test_season_digest.py
@@ -13,13 +13,20 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from tools.season_digest import (
     KNOWN_SEASONS,
+    _DISCORD_EMBED_TOTAL_LIMIT,
+    _DISCORD_FIELD_VALUE_LIMIT,
+    _DISCORD_TITLE_LIMIT,
+    _SEASON_COLOURS,
     _significance_score,
-    build_stats,
+    _truncate,
+    build_collaborations,
+    build_digest,
+    build_discord_embed,
     build_highlights,
     build_peak_moment,
-    build_collaborations,
+    build_stats,
     build_arc_summary,
-    build_digest,
+    render_discord,
     render_markdown,
     main,
 )
@@ -574,6 +581,310 @@ class TestCLI(unittest.TestCase):
     def test_sparse_season_no_crash(self):
         rc, _, _ = _run(["--season", "1"])
         self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# _truncate helper
+# ---------------------------------------------------------------------------
+
+class TestTruncate(unittest.TestCase):
+
+    def test_short_string_unchanged(self):
+        self.assertEqual(_truncate("hello", 20), "hello")
+
+    def test_exact_length_unchanged(self):
+        self.assertEqual(_truncate("hello", 5), "hello")
+
+    def test_long_string_truncated(self):
+        result = _truncate("hello world foo bar", 10)
+        self.assertLessEqual(len(result), 10)
+
+    def test_suffix_appended_when_cut(self):
+        result = _truncate("hello world", 8)
+        self.assertTrue(result.endswith(" …"))
+
+    def test_word_boundary_respected(self):
+        # "hello world" → should cut after "hello" not mid-"world"
+        result = _truncate("hello world this is long", 12)
+        self.assertNotIn("wor", result.split(" …")[0].split()[-1][:3])
+
+    def test_custom_suffix(self):
+        result = _truncate("hello world", 8, suffix="...")
+        self.assertTrue(result.endswith("..."))
+
+    def test_empty_string(self):
+        self.assertEqual(_truncate("", 10), "")
+
+
+# ---------------------------------------------------------------------------
+# build_discord_embed
+# ---------------------------------------------------------------------------
+
+class TestBuildDiscordEmbed(unittest.TestCase):
+
+    def _embed(self, season: int = 9) -> dict:
+        return build_discord_embed(build_digest(season))
+
+    # Structure ---------------------------------------------------------------
+
+    def test_returns_dict(self):
+        self.assertIsInstance(self._embed(), dict)
+
+    def test_has_title(self):
+        self.assertIn("title", self._embed())
+
+    def test_has_color(self):
+        self.assertIn("color", self._embed())
+
+    def test_has_fields_list(self):
+        embed = self._embed()
+        self.assertIn("fields", embed)
+        self.assertIsInstance(embed["fields"], list)
+
+    def test_has_footer(self):
+        self.assertIn("footer", self._embed())
+
+    def test_footer_has_text(self):
+        self.assertIn("text", self._embed()["footer"])
+
+    def test_title_contains_season_number(self):
+        self.assertIn("9", self._embed(9)["title"])
+
+    def test_footer_contains_season_number(self):
+        self.assertIn("9", self._embed(9)["footer"]["text"])
+
+    # Limits ------------------------------------------------------------------
+
+    def test_title_within_limit(self):
+        self.assertLessEqual(len(self._embed()["title"]), _DISCORD_TITLE_LIMIT)
+
+    def test_all_field_values_within_limit(self):
+        for field in self._embed()["fields"]:
+            self.assertLessEqual(
+                len(field["value"]),
+                _DISCORD_FIELD_VALUE_LIMIT,
+                f"Field '{field['name']}' exceeds value limit",
+            )
+
+    def test_total_embed_chars_within_limit(self):
+        embed = self._embed()
+        total = len(embed.get("title", ""))
+        for f in embed.get("fields", []):
+            total += len(f.get("name", "")) + len(f.get("value", ""))
+        total += len(embed.get("footer", {}).get("text", ""))
+        self.assertLessEqual(total, _DISCORD_EMBED_TOTAL_LIMIT)
+
+    def test_limits_hold_for_all_seasons(self):
+        for s in KNOWN_SEASONS:
+            embed = self._embed(s)
+            # title limit
+            self.assertLessEqual(len(embed["title"]), _DISCORD_TITLE_LIMIT,
+                                 f"Season {s} title over limit")
+            # field value limits
+            for f in embed["fields"]:
+                self.assertLessEqual(len(f["value"]), _DISCORD_FIELD_VALUE_LIMIT,
+                                     f"Season {s} field '{f['name']}' over limit")
+            # total limit
+            total = len(embed.get("title", ""))
+            for f in embed.get("fields", []):
+                total += len(f.get("name", "")) + len(f.get("value", ""))
+            total += len(embed.get("footer", {}).get("text", ""))
+            self.assertLessEqual(total, _DISCORD_EMBED_TOTAL_LIMIT,
+                                 f"Season {s} total embed over limit")
+
+    # Content -----------------------------------------------------------------
+
+    def test_fields_nonempty(self):
+        self.assertGreater(len(self._embed()["fields"]), 0)
+
+    def test_quick_stats_field_present(self):
+        names = [f["name"] for f in self._embed()["fields"]]
+        self.assertTrue(any("Stats" in n for n in names))
+
+    def test_season_arc_field_present(self):
+        names = [f["name"] for f in self._embed()["fields"]]
+        self.assertTrue(any("Arc" in n for n in names))
+
+    def test_peak_moment_field_present_when_data_exists(self):
+        names = [f["name"] for f in self._embed(9)["fields"]]
+        self.assertTrue(any("Peak" in n for n in names))
+
+    def test_highlights_field_present(self):
+        names = [f["name"] for f in self._embed(9)["fields"]]
+        self.assertTrue(any("Highlight" in n for n in names))
+
+    def test_collaborations_field_present(self):
+        names = [f["name"] for f in self._embed()["fields"]]
+        self.assertTrue(any("Collab" in n for n in names))
+
+    def test_colour_distinct_per_season(self):
+        # Each season should get a unique colour integer
+        colours = [build_discord_embed(build_digest(s))["color"]
+                   for s in KNOWN_SEASONS]
+        self.assertEqual(len(colours), len(set(colours)),
+                         "Two seasons share the same embed colour")
+
+    def test_all_fields_have_inline_key(self):
+        for field in self._embed()["fields"]:
+            self.assertIn("inline", field)
+
+    def test_field_name_within_limit(self):
+        for field in self._embed()["fields"]:
+            self.assertLessEqual(len(field["name"]), _DISCORD_FIELD_VALUE_LIMIT)
+
+    def test_no_empty_field_values(self):
+        for field in self._embed()["fields"]:
+            self.assertGreater(len(field["value"].strip()), 0,
+                               f"Field '{field['name']}' has empty value")
+
+    def test_json_serialisable(self):
+        serialised = json.dumps(self._embed())
+        self.assertIsInstance(serialised, str)
+
+    # Season with no peak moment (all-empty digest) ---------------------------
+
+    def test_no_peak_moment_no_crash(self):
+        digest = build_digest(9)
+        digest["peak_moment"] = None
+        embed = build_discord_embed(digest)
+        self.assertIsInstance(embed, dict)
+
+    def test_empty_digest_no_crash(self):
+        digest = {
+            "season": 9, "stats": {}, "highlights": [],
+            "peak_moment": None, "collaborations": [], "arc_summary": "",
+        }
+        embed = build_discord_embed(digest)
+        self.assertIsInstance(embed, dict)
+
+
+# ---------------------------------------------------------------------------
+# render_discord
+# ---------------------------------------------------------------------------
+
+class TestRenderDiscord(unittest.TestCase):
+
+    def _payload(self, season: int = 9) -> dict:
+        return json.loads(render_discord(build_digest(season)))
+
+    def test_returns_string(self):
+        self.assertIsInstance(render_discord(build_digest(9)), str)
+
+    def test_valid_json(self):
+        raw = render_discord(build_digest(9))
+        self.assertIsInstance(json.loads(raw), dict)
+
+    def test_outer_key_is_embeds(self):
+        payload = self._payload()
+        self.assertIn("embeds", payload)
+
+    def test_embeds_is_list(self):
+        self.assertIsInstance(self._payload()["embeds"], list)
+
+    def test_exactly_one_embed(self):
+        self.assertEqual(len(self._payload()["embeds"]), 1)
+
+    def test_embed_has_title(self):
+        self.assertIn("title", self._payload()["embeds"][0])
+
+    def test_embed_has_fields(self):
+        self.assertIn("fields", self._payload()["embeds"][0])
+
+
+# ---------------------------------------------------------------------------
+# CLI — --discord flag
+# ---------------------------------------------------------------------------
+
+class TestCLIDiscord(unittest.TestCase):
+
+    def test_discord_exits_0(self):
+        rc, _, _ = _run(["--season", "9", "--discord"])
+        self.assertEqual(rc, 0)
+
+    def test_discord_produces_valid_json(self):
+        _, out, _ = _run(["--season", "9", "--discord"])
+        data = json.loads(out)
+        self.assertIsInstance(data, dict)
+
+    def test_discord_outer_key_embeds(self):
+        _, out, _ = _run(["--season", "9", "--discord"])
+        data = json.loads(out)
+        self.assertIn("embeds", data)
+
+    def test_discord_embed_title_present(self):
+        _, out, _ = _run(["--season", "9", "--discord"])
+        data = json.loads(out)
+        self.assertIn("title", data["embeds"][0])
+
+    def test_discord_season_in_title(self):
+        _, out, _ = _run(["--season", "9", "--discord"])
+        data = json.loads(out)
+        self.assertIn("9", data["embeds"][0]["title"])
+
+    def test_discord_field_values_within_limit(self):
+        _, out, _ = _run(["--season", "9", "--discord"])
+        data = json.loads(out)
+        for field in data["embeds"][0]["fields"]:
+            self.assertLessEqual(len(field["value"]), _DISCORD_FIELD_VALUE_LIMIT)
+
+    def test_discord_total_chars_within_limit(self):
+        _, out, _ = _run(["--season", "9", "--discord"])
+        embed = json.loads(out)["embeds"][0]
+        total = len(embed.get("title", ""))
+        for f in embed.get("fields", []):
+            total += len(f.get("name", "")) + len(f.get("value", ""))
+        total += len(embed.get("footer", {}).get("text", ""))
+        self.assertLessEqual(total, _DISCORD_EMBED_TOTAL_LIMIT)
+
+    def test_discord_mutually_exclusive_with_json(self):
+        rc, _, _ = _run(["--season", "9", "--discord", "--json"])
+        self.assertNotEqual(rc, 0)
+
+    def test_discord_mutually_exclusive_with_markdown(self):
+        rc, _, _ = _run(["--season", "9", "--discord", "--markdown"])
+        self.assertNotEqual(rc, 0)
+
+    def test_discord_top_flag_respected(self):
+        _, out, _ = _run(["--season", "9", "--discord", "--top", "2"])
+        data = json.loads(out)
+        fields = data["embeds"][0]["fields"]
+        highlight_field = next(
+            (f for f in fields if "Highlight" in f["name"]), None
+        )
+        if highlight_field:
+            # At most 2 numbered entries; "…" is allowed as a trailing line
+            numbered = [ln for ln in highlight_field["value"].splitlines()
+                        if ln and ln[0].isdigit()]
+            self.assertLessEqual(len(numbered), 2)
+
+    def test_discord_unknown_season_exits_1(self):
+        rc, _, err = _run(["--season", "999", "--discord"])
+        self.assertEqual(rc, 1)
+
+    def test_discord_all_seasons_exit_0(self):
+        for s in KNOWN_SEASONS:
+            rc, _, _ = _run(["--season", str(s), "--discord"])
+            self.assertEqual(rc, 0, f"Season {s} exited nonzero with --discord")
+
+    def test_discord_sparse_season_no_crash(self):
+        rc, out, _ = _run(["--season", "1", "--discord"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIn("embeds", data)
+
+    # Season colours ----------------------------------------------------------
+
+    def test_season_colour_all_11_defined(self):
+        self.assertEqual(len(_SEASON_COLOURS), 11)
+
+    def test_all_season_colours_positive_ints(self):
+        for s, c in _SEASON_COLOURS.items():
+            self.assertIsInstance(c, int)
+            self.assertGreater(c, 0, f"Season {s} colour must be positive")
+
+    def test_season_colours_all_distinct(self):
+        colours = list(_SEASON_COLOURS.values())
+        self.assertEqual(len(colours), len(set(colours)))
 
 
 if __name__ == "__main__":

--- a/tools/season_digest.py
+++ b/tools/season_digest.py
@@ -4,7 +4,8 @@ tools/season_digest.py — Shareable "Season in Review" digest generator.
 Combines per-season highlights, collaborations, and a narrative arc summary
 into one ready-to-share document.  The markdown output can be pasted directly
 into a Discord message, a Reddit post, or a wiki page; the JSON output feeds
-downstream tools such as a Discord bot or static site generator.
+downstream tools such as a Discord bot or static site generator; the Discord
+embed output can be POSTed directly to a Discord webhook.
 
 Sections in every digest:
   1. Quick stats  — date range, hermit count, event-type breakdown
@@ -17,12 +18,18 @@ Sections in every digest:
 Output modes:
   --markdown  (default)  Ready-to-paste .md document with headers / bullets
   --json                 Structured dict for downstream tooling
+  --discord              Discord embed JSON payload (POST to a webhook directly)
+
+Discord embed limits enforced automatically:
+  Field value  ≤ 1 024 chars   Embed title ≤ 256 chars
+  Total embed  ≤ 6 000 chars   Truncated with … rather than hard-cut
 
 Usage:
     python -m tools.season_digest --season 9
     python -m tools.season_digest --season 9 --top 3
     python -m tools.season_digest --season 9 --json
     python -m tools.season_digest --season 9 --markdown
+    python -m tools.season_digest --season 9 --discord
     python -m tools.season_digest --list
 """
 
@@ -455,6 +462,259 @@ def render_markdown(digest: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Discord embed renderer
+# ---------------------------------------------------------------------------
+
+# Discord API hard limits
+_DISCORD_TITLE_LIMIT: int = 256
+_DISCORD_FIELD_VALUE_LIMIT: int = 1024
+_DISCORD_EMBED_TOTAL_LIMIT: int = 6000
+_DISCORD_FIELD_NAME_LIMIT: int = 256
+
+# One distinct colour per season (decimal RGB, matching Discord's colour int).
+# Chosen to be visually distinct across the 11 seasons.
+_SEASON_COLOURS: dict[int, int] = {
+    1:  0x1ABC9C,   # teal          — founding era
+    2:  0x2ECC71,   # green
+    3:  0x3498DB,   # blue
+    4:  0x9B59B6,   # purple
+    5:  0xE91E63,   # pink
+    6:  0xF39C12,   # orange        — "golden age" begins
+    7:  0xE74C3C,   # red
+    8:  0x1E88E5,   # bright blue   — Demise / Last Life cross-over era
+    9:  0x00BCD4,   # cyan          — longest season ever
+    10: 0x8BC34A,   # lime green
+    11: 0x7E57C2,   # indigo
+}
+_COLOUR_DEFAULT: int = 0x99AAB5  # Discord grey fallback
+
+
+def _truncate(text: str, max_len: int, suffix: str = " …") -> str:
+    """Return *text* truncated to *max_len* chars, appending *suffix* if cut.
+
+    Truncation is word-aware: the cut happens at the last space before the
+    limit so words are never split mid-character.
+    """
+    if len(text) <= max_len:
+        return text
+    cut_at = max_len - len(suffix)
+    # Walk back to a word boundary
+    boundary = text.rfind(" ", 0, cut_at)
+    if boundary <= 0:
+        boundary = cut_at
+    return text[:boundary] + suffix
+
+
+def _discord_stats_value(stats: dict) -> str:
+    """Compact stats line for a Discord embed field value."""
+    date_start = stats.get("date_start") or "unknown"
+    date_end = stats.get("date_end") or "unknown"
+    hermit_count = stats.get("hermit_count", 0)
+    event_count = stats.get("event_count", 0)
+    breakdown = stats.get("type_breakdown", {})
+
+    lines = [
+        f"📅 {date_start} → {date_end}",
+        f"👥 {hermit_count} hermits · {event_count} documented events",
+    ]
+    if breakdown:
+        top_types = sorted(breakdown.items(), key=lambda x: -x[1])[:3]
+        lines.append("📊 " + ", ".join(f"{t}: {c}" for t, c in top_types))
+
+    return "\n".join(lines)
+
+
+def _discord_peak_value(peak: dict) -> str:
+    """One-block peak-moment field value."""
+    title = peak.get("title", "(untitled)")
+    score = peak.get("significance_score", 0)
+    date = peak.get("date", "")
+    hermits = peak.get("hermits", [])
+    desc = peak.get("description", "")
+
+    hermit_str = "All hermits" if hermits == ["All"] else ", ".join(hermits[:3])
+    header = f"**{title}** *(score: {score})*"
+    meta = f"{date} · {hermit_str}" if date else hermit_str
+
+    parts = [header, meta]
+    if desc:
+        # Trim description to fit remaining budget in the field
+        budget = _DISCORD_FIELD_VALUE_LIMIT - len(header) - len(meta) - 4
+        if budget > 40:
+            parts.append(_truncate(desc, budget))
+
+    return "\n".join(p for p in parts if p)
+
+
+def _discord_highlights_value(highlights: list[dict]) -> str:
+    """Numbered list of highlights, truncated to fit the field limit."""
+    lines: list[str] = []
+    for entry in highlights:
+        rank = entry["rank"]
+        title = entry["title"]
+        ev_type = entry.get("type", "")
+        score = entry.get("significance_score", 0)
+        type_tag = f" `{ev_type}`" if ev_type else ""
+        line = f"{rank}. **{title}**{type_tag} *(score: {score})*"
+        # Add line only while we stay within the limit
+        candidate = "\n".join(lines + [line])
+        if len(candidate) > _DISCORD_FIELD_VALUE_LIMIT - 4:
+            lines.append(" …")
+            break
+        lines.append(line)
+    return "\n".join(lines) if lines else "*No highlights available.*"
+
+
+def _discord_collabs_value(collabs: list[dict]) -> str:
+    """Bullet list of top collaborating pairs."""
+    if not collabs:
+        return "*No multi-hermit collaborations recorded.*"
+    lines: list[str] = []
+    for entry in collabs:
+        a = entry["hermit_a"]
+        b = entry["hermit_b"]
+        count = entry["shared_event_count"]
+        plural = "s" if count != 1 else ""
+        titles = entry.get("event_titles", [])
+        title_note = f" — {titles[0]}" if titles else ""
+        line = f"• **{a} & {b}**: {count} event{plural}{title_note}"
+        candidate = "\n".join(lines + [line])
+        if len(candidate) > _DISCORD_FIELD_VALUE_LIMIT - 4:
+            lines.append(" …")
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def build_discord_embed(digest: dict) -> dict:
+    """
+    Build a Discord embed dict from *digest*.
+
+    The returned dict is a single embed object (not the outer ``{"embeds": […]}``
+    wrapper) so callers can compose multiple embeds if needed.
+
+    All field values are guaranteed to be ≤ ``_DISCORD_FIELD_VALUE_LIMIT``
+    characters.  The function also trims the total embed character count to
+    stay within ``_DISCORD_EMBED_TOTAL_LIMIT``.
+
+    Structure::
+
+        {
+            "title":  "🏆 Hermitcraft Season N — Season in Review",
+            "color":  <int>,
+            "fields": [
+                {"name": "📊 Quick Stats",         "value": "…", "inline": False},
+                {"name": "📖 Season Arc",           "value": "…", "inline": False},
+                {"name": "🌟 Peak Moment",          "value": "…", "inline": False},
+                {"name": "🏅 Top Highlights",       "value": "…", "inline": False},
+                {"name": "🤝 Notable Collaborations","value": "…", "inline": False},
+            ],
+            "footer": {"text": "hermitcraft-agent • /digest season N"},
+        }
+    """
+    season = digest["season"]
+    stats = digest.get("stats", {})
+    highlights = digest.get("highlights", [])
+    peak = digest.get("peak_moment")
+    collabs = digest.get("collaborations", [])
+    arc = digest.get("arc_summary", "")
+
+    title = _truncate(
+        f"🏆 Hermitcraft Season {season} — Season in Review",
+        _DISCORD_TITLE_LIMIT,
+    )
+    colour = _SEASON_COLOURS.get(season, _COLOUR_DEFAULT)
+
+    # Arc: trim to 2 sentences for embed brevity
+    arc_sentences = [s.strip() for s in arc.split(".") if s.strip()]
+    arc_short = ". ".join(arc_sentences[:2]) + ("." if arc_sentences else "")
+    arc_value = _truncate(arc_short, _DISCORD_FIELD_VALUE_LIMIT)
+
+    fields: list[dict] = [
+        {
+            "name": "📊 Quick Stats",
+            "value": _truncate(_discord_stats_value(stats),
+                                _DISCORD_FIELD_VALUE_LIMIT),
+            "inline": False,
+        },
+        {
+            "name": "📖 Season Arc",
+            "value": arc_value or "*No arc summary available.*",
+            "inline": False,
+        },
+    ]
+
+    if peak:
+        fields.append(
+            {
+                "name": "🌟 Peak Moment",
+                "value": _truncate(_discord_peak_value(peak),
+                                   _DISCORD_FIELD_VALUE_LIMIT),
+                "inline": False,
+            }
+        )
+
+    if highlights:
+        fields.append(
+            {
+                "name": f"🏅 Top {len(highlights)} Highlights",
+                "value": _discord_highlights_value(highlights),
+                "inline": False,
+            }
+        )
+
+    fields.append(
+        {
+            "name": "🤝 Notable Collaborations",
+            "value": _discord_collabs_value(collabs),
+            "inline": False,
+        }
+    )
+
+    embed: dict = {
+        "title": title,
+        "color": colour,
+        "fields": fields,
+        "footer": {"text": f"hermitcraft-agent • /digest season {season}"},
+    }
+
+    # ── Safety trim: ensure total character count ≤ embed limit ─────────────
+    # Count: title + all field names + all field values + footer text
+    def _embed_char_count(e: dict) -> int:
+        total = len(e.get("title", ""))
+        for f in e.get("fields", []):
+            total += len(f.get("name", "")) + len(f.get("value", ""))
+        total += len(e.get("footer", {}).get("text", ""))
+        return total
+
+    # If over limit, progressively shorten the longest field values
+    while _embed_char_count(embed) > _DISCORD_EMBED_TOTAL_LIMIT and embed["fields"]:
+        # Find the field with the longest value and shorten it
+        longest = max(embed["fields"], key=lambda f: len(f["value"]))
+        if len(longest["value"]) <= 50:
+            # Nothing meaningful left to trim; remove the field instead
+            embed["fields"].remove(longest)
+        else:
+            longest["value"] = _truncate(
+                longest["value"],
+                len(longest["value"]) - 100,
+            )
+
+    return embed
+
+
+def render_discord(digest: dict) -> str:
+    """
+    Render *digest* as a Discord webhook-ready JSON string.
+
+    The output is the ``{"embeds": […]}`` wrapper expected by the Discord
+    webhook API — pipe it straight to ``curl -d @- <webhook_url>``.
+    """
+    embed = build_discord_embed(digest)
+    return json.dumps({"embeds": [embed]}, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -500,6 +760,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default=False,
         help="Output as JSON",
     )
+    fmt_group.add_argument(
+        "--discord",
+        action="store_true",
+        default=False,
+        help=(
+            "Output as a Discord embed JSON payload — POST directly to a "
+            "webhook.  Field values are automatically trimmed to Discord's "
+            "1 024-char limit; total embed stays under 6 000 chars."
+        ),
+    )
     return p
 
 
@@ -524,6 +794,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.json:
         print(json.dumps(digest, indent=2))
+    elif args.discord:
+        print(render_discord(digest))
     else:
         # --markdown is default when neither flag is given
         print(render_markdown(digest))


### PR DESCRIPTION
## Summary

Adds a \`--discord\` output flag to \`tools/season_digest.py\`, making the Season in Review digest directly deployable to a Discord webhook.

**New public API:**
- \`build_discord_embed(digest)\` — builds a single Discord embed dict from a digest; independently testable, composable into multi-embed payloads
- \`render_discord(digest)\` — returns the outer \`{"embeds": […]}\` JSON string POSTable straight to a Discord webhook URL
- \`_truncate(text, max_len, suffix)\` — word-boundary-aware truncation helper used throughout the embed builder

**Discord constraints enforced automatically:**
- Embed title ≤ 256 chars
- Field value ≤ 1 024 chars
- Total embed ≤ 6 000 chars (iterative trimming loop)

**Per-season colours:** each of the 11 seasons maps to a distinct Discord colour int, verified distinct by test.

**Tests added:** 55 new tests (143 total)
- \`TestTruncate\` (7), \`TestBuildDiscordEmbed\` (26), \`TestRenderDiscord\` (7), \`TestCLIDiscord\` (15)
- All Discord limit invariants verified across all 11 seasons

## Test plan
- [x] \`python3 -m unittest tests.test_season_digest -v\` — 143 tests, all pass
- [x] \`--discord\` produces valid webhook JSON for all 11 seasons
- [x] All field values ≤ 1024, total ≤ 6000, title ≤ 256
- [x] Mutually exclusive with \`--json\` and \`--markdown\`

Closes #109