### PR TITLE
[hermitcraft-agent] Add global collaboration heatmap (--global-leaderboard)

### DIFF
--- a/tests/test_global_leaderboard.py
+++ b/tests/test_global_leaderboard.py
@@ -1,0 +1,260 @@
+"""
+Tests for the --global-leaderboard feature in tools/collab_query.py.
+
+Covers:
+  - build_global_leaderboard() core logic
+  - format_global_leaderboard() output formatting
+  - CLI --global-leaderboard flag (text + JSON modes)
+  - Composability with --season, --top, --json
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.collab_query import (
+    build_global_leaderboard,
+    format_global_leaderboard,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_global_leaderboard — unit tests
+# ---------------------------------------------------------------------------
+
+class TestBuildGlobalLeaderboard(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Build once; all tests share the result."""
+        cls.leaderboard = build_global_leaderboard()
+
+    def test_returns_list(self):
+        self.assertIsInstance(self.leaderboard, list)
+
+    def test_non_empty(self):
+        self.assertGreater(len(self.leaderboard), 0)
+
+    def test_each_entry_has_required_keys(self):
+        for entry in self.leaderboard:
+            for key in ("rank", "hermit", "total_events", "partner_count", "seasons"):
+                self.assertIn(key, entry, f"Missing key '{key}' in {entry}")
+
+    def test_ranks_are_sequential(self):
+        ranks = [e["rank"] for e in self.leaderboard]
+        self.assertEqual(ranks, list(range(1, len(self.leaderboard) + 1)))
+
+    def test_sorted_by_total_events_descending(self):
+        totals = [e["total_events"] for e in self.leaderboard]
+        self.assertEqual(totals, sorted(totals, reverse=True))
+
+    def test_total_events_positive(self):
+        for entry in self.leaderboard:
+            self.assertGreater(entry["total_events"], 0,
+                               f"{entry['hermit']} has 0 events but is in leaderboard")
+
+    def test_partner_count_positive(self):
+        for entry in self.leaderboard:
+            self.assertGreater(entry["partner_count"], 0)
+
+    def test_partner_count_lte_total_hermits(self):
+        from tools.collab_query import _all_hermit_names
+        n_hermits = len(_all_hermit_names())
+        for entry in self.leaderboard:
+            self.assertLessEqual(entry["partner_count"], n_hermits - 1)
+
+    def test_seasons_is_sorted_list(self):
+        for entry in self.leaderboard:
+            seasons = entry["seasons"]
+            self.assertIsInstance(seasons, list)
+            self.assertEqual(seasons, sorted(seasons))
+
+    def test_no_duplicate_hermits(self):
+        names = [e["hermit"] for e in self.leaderboard]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_top_n_respected(self):
+        top3 = build_global_leaderboard(top_n=3)
+        self.assertLessEqual(len(top3), 3)
+
+    def test_top_n_1(self):
+        top1 = build_global_leaderboard(top_n=1)
+        self.assertEqual(len(top1), 1)
+        self.assertEqual(top1[0]["rank"], 1)
+
+    def test_season_filter(self):
+        result_s9 = build_global_leaderboard(season_filter=9)
+        # All returned events should only be from season 9
+        for entry in result_s9:
+            seasons = entry["seasons"]
+            for s in seasons:
+                self.assertEqual(s, 9,
+                                 f"{entry['hermit']} has season {s} with season_filter=9")
+
+    def test_season_filter_result_smaller_than_all(self):
+        all_result = build_global_leaderboard()
+        s9_result = build_global_leaderboard(season_filter=9)
+        # S9-filtered result should have ≤ total events per hermit
+        all_map = {e["hermit"]: e["total_events"] for e in all_result}
+        for entry in s9_result:
+            if entry["hermit"] in all_map:
+                self.assertLessEqual(
+                    entry["total_events"], all_map[entry["hermit"]],
+                    msg=f"{entry['hermit']} has MORE events in S9 than overall"
+                )
+
+    def test_first_place_has_most_events(self):
+        lb = build_global_leaderboard()
+        if len(lb) >= 2:
+            self.assertGreaterEqual(lb[0]["total_events"], lb[1]["total_events"])
+
+
+# ---------------------------------------------------------------------------
+# format_global_leaderboard — output tests
+# ---------------------------------------------------------------------------
+
+class TestFormatGlobalLeaderboard(unittest.TestCase):
+    def setUp(self):
+        self.ranked = build_global_leaderboard(top_n=5)
+        self.text = format_global_leaderboard(self.ranked)
+
+    def test_returns_string(self):
+        self.assertIsInstance(self.text, str)
+
+    def test_non_empty(self):
+        self.assertGreater(len(self.text), 50)
+
+    def test_contains_header(self):
+        self.assertIn("Most-connected Hermits", self.text)
+
+    def test_contains_rank_numbers(self):
+        self.assertIn("1.", self.text)
+
+    def test_contains_collab_partners_label(self):
+        self.assertIn("collab partners", self.text)
+
+    def test_season_filter_in_header(self):
+        text = format_global_leaderboard(self.ranked, season_filter=9)
+        self.assertIn("Season 9", text)
+
+    def test_empty_ranked_shows_no_data(self):
+        text = format_global_leaderboard([])
+        self.assertIn("no collaboration", text.lower())
+
+    def test_all_hermits_appear(self):
+        for entry in self.ranked:
+            self.assertIn(entry["hermit"], self.text)
+
+    def test_total_events_shown(self):
+        # The first entry's count should appear somewhere in the output
+        if self.ranked:
+            count = str(self.ranked[0]["total_events"])
+            self.assertIn(count, self.text)
+
+
+# ---------------------------------------------------------------------------
+# CLI — global-leaderboard flag
+# ---------------------------------------------------------------------------
+
+class TestGlobalLeaderboardCLI(unittest.TestCase):
+    def test_global_leaderboard_flag_exits_0(self):
+        rc = main(["--global-leaderboard"])
+        self.assertEqual(rc, 0)
+
+    def test_global_leaderboard_json(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["--global-leaderboard", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["mode"], "global_leaderboard")
+        self.assertIn("leaderboard", data)
+        self.assertIn("top_n", data)
+        self.assertIsInstance(data["leaderboard"], list)
+        for entry in data["leaderboard"]:
+            self.assertIn("rank", entry)
+            self.assertIn("hermit", entry)
+            self.assertIn("total_events", entry)
+            self.assertIn("partner_count", entry)
+
+    def test_global_leaderboard_top_flag(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["--global-leaderboard", "--top", "5", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertLessEqual(len(data["leaderboard"]), 5)
+        self.assertEqual(data["top_n"], 5)
+
+    def test_global_leaderboard_season_flag(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["--global-leaderboard", "--season", "9", "--json"])
+        self.assertIn(rc, (0, 1))
+        if rc == 0:
+            data = json.loads(buf.getvalue())
+            self.assertEqual(data.get("season_filter"), 9)
+            for entry in data["leaderboard"]:
+                for s in entry["seasons"]:
+                    self.assertEqual(s, 9)
+
+    def test_global_leaderboard_json_has_season_filter_key(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            main(["--global-leaderboard", "--season", "7", "--json"])
+        data = json.loads(buf.getvalue())
+        self.assertIn("season_filter", data)
+        self.assertEqual(data["season_filter"], 7)
+
+    def test_global_leaderboard_text_output(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["--global-leaderboard"])
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        self.assertIn("Most-connected Hermits", output)
+        self.assertIn("collab partners", output)
+
+    def test_global_leaderboard_no_hermit_a_required(self):
+        """--global-leaderboard should not require --hermit-a."""
+        rc = main(["--global-leaderboard", "--top", "3"])
+        self.assertEqual(rc, 0)
+
+    def test_hermit_a_still_works_with_top_collabs(self):
+        """Existing --top-collabs mode should be unaffected."""
+        rc = main(["--hermit-a", "Grian", "--top-collabs", "--top", "3"])
+        self.assertEqual(rc, 0)
+
+    def test_subprocess_global_leaderboard(self):
+        proc = subprocess.run(
+            [sys.executable, "-m", "tools.collab_query",
+             "--global-leaderboard", "--top", "5"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("Most-connected Hermits", proc.stdout)
+
+    def test_subprocess_global_leaderboard_json(self):
+        proc = subprocess.run(
+            [sys.executable, "-m", "tools.collab_query",
+             "--global-leaderboard", "--json", "--top", "3"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        self.assertEqual(proc.returncode, 0)
+        data = json.loads(proc.stdout)
+        self.assertIn("leaderboard", data)
+        self.assertLessEqual(len(data["leaderboard"]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/collab_query.py
+++ b/tools/collab_query.py
@@ -14,11 +14,17 @@ Usage:
     python -m tools.collab_query --hermit-a EthosLab --hermit-b BdoubleO100 --json
     python -m tools.collab_query --hermit-a Grian --hermit-b Scar --types lore build
 
-    # Top-collaborators leaderboard mode:
+    # Top-collaborators leaderboard mode (one hermit vs all others):
     python -m tools.collab_query --hermit-a Grian --top-collabs
     python -m tools.collab_query --hermit-a TangoTek --top-collabs --top 5
     python -m tools.collab_query --hermit-a Iskall85 --top-collabs --season 8
     python -m tools.collab_query --hermit-a Grian --top-collabs --json
+
+    # Global leaderboard mode (all hermits ranked by social connectivity):
+    python -m tools.collab_query --global-leaderboard
+    python -m tools.collab_query --global-leaderboard --season 8
+    python -m tools.collab_query --global-leaderboard --top 10
+    python -m tools.collab_query --global-leaderboard --json
 """
 
 from __future__ import annotations
@@ -335,6 +341,120 @@ def format_text(output: dict) -> str:
     return "\n".join(lines)
 
 
+def build_global_leaderboard(
+    season_filter: int | None = None,
+    type_filter: list[str] | None = None,
+    top_n: int = 20,
+) -> list[dict]:
+    """
+    Rank every hermit by their total shared-event count across all other hermits.
+
+    For each hermit, iterates over all *other* hermits and counts unique shared
+    events (deduplicated by event id).  Also records the number of distinct
+    collab partners (hermits with at least one shared event).
+
+    Args:
+        season_filter: If given, restrict to this season number.
+        type_filter: If given, restrict to events of these types.
+        top_n: Maximum number of entries to return (default 20).
+
+    Returns:
+        List of dicts sorted descending by total_events, then partner_count,
+        then hermit name.  Each dict has keys:
+            rank, hermit, total_events, partner_count, seasons
+    """
+    all_names = _all_hermit_names()
+    cached_events = _load_all_events()
+
+    # Build a map: hermit_name → {event_ids, partner_names, seasons}
+    hermit_data: dict[str, dict] = {
+        name: {"event_ids": set(), "partners": set(), "seasons": set()}
+        for name in all_names
+    }
+
+    # Scan all pairs (A, B) with A < B to avoid double-counting
+    for i, name_a in enumerate(all_names):
+        for name_b in all_names[i + 1:]:
+            shared = find_shared_events(
+                name_a,
+                name_b,
+                season_filter=season_filter,
+                type_filter=type_filter,
+                _events=cached_events,
+            )
+            if not shared:
+                continue
+            for ev in shared:
+                ev_id = ev.get("id") or ev.get("title", "")
+                hermit_data[name_a]["event_ids"].add(ev_id)
+                hermit_data[name_b]["event_ids"].add(ev_id)
+                s = ev.get("season")
+                if isinstance(s, int):
+                    hermit_data[name_a]["seasons"].add(s)
+                    hermit_data[name_b]["seasons"].add(s)
+            hermit_data[name_a]["partners"].add(name_b)
+            hermit_data[name_b]["partners"].add(name_a)
+
+    # Flatten and sort
+    flat = []
+    for name, data in hermit_data.items():
+        total = len(data["event_ids"])
+        if total == 0:
+            continue
+        flat.append({
+            "hermit": name,
+            "total_events": total,
+            "partner_count": len(data["partners"]),
+            "seasons": sorted(data["seasons"]),
+        })
+
+    flat.sort(key=lambda x: (-x["total_events"], -x["partner_count"], x["hermit"].lower()))
+
+    ranked = []
+    for i, entry in enumerate(flat[:top_n], start=1):
+        ranked.append({"rank": i, **entry})
+    return ranked
+
+
+def format_global_leaderboard(
+    ranked: list[dict],
+    season_filter: int | None = None,
+    type_filter: list[str] | None = None,
+) -> str:
+    """Format the global leaderboard as a human-readable table."""
+    season_label = f"Season {season_filter}" if season_filter else "all seasons"
+    type_label = f", types: {', '.join(type_filter)}" if type_filter else ""
+    lines: list[str] = []
+    lines.append(f"Most-connected Hermits ({season_label}{type_label}):")
+    lines.append("")
+
+    if not ranked:
+        lines.append("  (no collaboration data found)")
+        return "\n".join(lines)
+
+    max_name = max(len(e["hermit"]) for e in ranked)
+    col_w = max(max_name, 8)
+
+    for entry in ranked:
+        rank = entry["rank"]
+        hermit = entry["hermit"]
+        total = entry["total_events"]
+        partners = entry["partner_count"]
+        seasons = entry.get("seasons", [])
+        s_str = ", ".join(f"S{s}" for s in seasons[:4])
+        if len(seasons) > 4:
+            s_str += f" +{len(seasons) - 4} more"
+        plural = "s" if total != 1 else " "
+        lines.append(
+            f"  {rank:2d}. {hermit:<{col_w}}  "
+            f"{total:3d} total shared event{plural}  "
+            f"(collab partners: {partners})"
+            + (f"  [{s_str}]" if s_str else "")
+        )
+
+    return "\n".join(lines)
+
+
 def format_top_collabs(
     name_a: str,
     ranked: list[dict],
@@ -378,15 +498,15 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="python -m tools.collab_query",
         description=(
             "Find shared Hermitcraft events between two Hermits. "
-            "Answers 'when did A and B collaborate?' or "
-            "'who does A collaborate with most?' (--top-collabs)."
+            "Answers 'when did A and B collaborate?', "
+            "'who does A collaborate with most?' (--top-collabs), or "
+            "'who are the most socially connected hermits overall?' (--global-leaderboard)."
         ),
     )
     p.add_argument(
         "--hermit-a",
-        required=True,
         metavar="NAME",
-        help="Target Hermit (case-insensitive, partial match ok)",
+        help="Target Hermit (case-insensitive, partial match ok). Required for pairwise and --top-collabs modes.",
     )
     p.add_argument(
         "--hermit-b",
@@ -397,6 +517,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--top-collabs",
         action="store_true",
         help="Leaderboard mode: rank all Hermits by shared-event count with --hermit-a",
+    )
+    p.add_argument(
+        "--global-leaderboard",
+        action="store_true",
+        dest="global_leaderboard",
+        help=(
+            "Global leaderboard mode: rank every Hermit by total shared-event count "
+            "across all others. Composable with --season, --top, --json. "
+            "--hermit-a is not required in this mode."
+        ),
     )
     p.add_argument(
         "--top",
@@ -429,9 +559,39 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
+    # ── Global leaderboard mode ───────────────────────────────────────────
+    if getattr(args, "global_leaderboard", False):
+        ranked = build_global_leaderboard(
+            season_filter=args.season,
+            type_filter=args.types,
+            top_n=args.top,
+        )
+        if args.json:
+            out: dict = {
+                "mode": "global_leaderboard",
+                "top_n": args.top,
+                "leaderboard": ranked,
+            }
+            if args.season is not None:
+                out["season_filter"] = args.season
+            if args.types is not None:
+                out["type_filter"] = args.types
+            print(json.dumps(out, indent=2))
+        else:
+            print(format_global_leaderboard(
+                ranked,
+                season_filter=args.season,
+                type_filter=args.types,
+            ))
+        return 0
+
+    # All other modes require --hermit-a
+    if not args.hermit_a:
+        parser.error("--hermit-a is required (or use --global-leaderboard)")
+
     # Validate mode
     if not args.top_collabs and args.hermit_b is None:
-        parser.error("--hermit-b is required unless --top-collabs is specified")
+        parser.error("--hermit-b is required unless --top-collabs or --global-leaderboard is specified")
 
     name_a = _resolve_hermit_name(args.hermit_a)
     if name_a is None:


### PR DESCRIPTION
## Summary

- Adds `--global-leaderboard` flag to `tools/collab_query.py` — ranks every hermit by total shared-event count across all others
- New `build_global_leaderboard(season_filter, type_filter, top_n)` scans all hermit pairs (A<B) once, deduplicates events by id, and tracks both `total_events` and `partner_count` per hermit
- New `format_global_leaderboard()` — tabular output: rank, name, total events, collab partner count, seasons covered
- `--global-leaderboard` does **not** require `--hermit-a` (unlike pairwise / `--top-collabs` modes)
- Fully composable with `--season N`, `--top N`, `--json`
- JSON output: `{"mode": "global_leaderboard", "top_n": N, "leaderboard": [...], "season_filter": N}`

## Usage

```bash
python -m tools.collab_query --global-leaderboard
python -m tools.collab_query --global-leaderboard --season 8
python -m tools.collab_query --global-leaderboard --top 10
python -m tools.collab_query --global-leaderboard --json
```

## Test plan

- [ ] `python3 -m unittest tests/test_global_leaderboard.py` — 34 new tests, all pass
- [ ] `python3 -m unittest tests/test_collab_query.py` — all 101 existing tests still pass
- [ ] `python3 -m tools.collab_query --global-leaderboard --top 5` — prints ranked table with hermit names, event counts, partner counts
- [ ] `python3 -m tools.collab_query --global-leaderboard --season 9 --json` — JSON output includes `season_filter: 9`, all entry seasons are `[9]`
- [ ] `python3 -m tools.collab_query --hermit-a Grian --top-collabs` — existing mode still works unchanged

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)