### PR TITLE
[hermitcraft-agent] Require PR URL as first line of completion reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,18 @@ rule automatically — it will fail if any `tools/*.py` file (other than
 `api_retry.py` itself) contains a bare `subprocess.run` call whose first
 argument list starts with `"gh"`.
 
+## Completion Reports
+
+When reporting that a task is done, **always open with the PR URL as the very first line**, before any other detail:
+
+```
+PR: https://github.com/rapartlu/agent-hermitcraft/pull/NNN
+
+<rest of summary…>
+```
+
+This is mandatory — not optional — so the orchestrator verifier and supervisor can extract the PR URL immediately without a follow-up dispatch.
+
 ## Commit Messages
 
 - Use conventional commits: `feat:`, `fix:`, `docs:`, `research:`, `chore:`


### PR DESCRIPTION
## Summary

- Adds a **Completion Reports** section to `CLAUDE.md` mandating that every task completion report opens with `PR: <url>` as the very first line
- Eliminates the pattern of supervisor follow-up tasks dispatched solely to confirm a PR URL that should have been in the original result (3 of 20 recent tasks were such follow-ups)

## Test plan

- [ ] Section is present and clearly worded in `CLAUDE.md`
- [ ] Format example shows `PR: https://github.com/rapartlu/agent-hermitcraft/pull/NNN` as line 1

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)