### PR TITLE
[hermitcraft-agent] feat: add most active hermits and notable builds to season digest

### DIFF
--- a/tests/test_season_digest.py
+++ b/tests/test_season_digest.py
@@ -23,6 +23,8 @@ from tools.season_digest import (
     build_digest,
     build_discord_embed,
     build_highlights,
+    build_most_active_hermits,
+    build_notable_builds,
     build_peak_moment,
     build_stats,
     build_arc_summary,
@@ -885,6 +887,288 @@ class TestCLIDiscord(unittest.TestCase):
     def test_season_colours_all_distinct(self):
         colours = list(_SEASON_COLOURS.values())
         self.assertEqual(len(colours), len(set(colours)))
+
+
+# ---------------------------------------------------------------------------
+# build_most_active_hermits
+# ---------------------------------------------------------------------------
+
+class TestBuildMostActiveHermits(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(hermits=["Grian", "Scar"], title="Event A"),
+            _make_event(hermits=["Grian", "Mumbo"], title="Event B"),
+            _make_event(hermits=["Grian"], title="Event C"),
+            _make_event(hermits=["Scar"], title="Event D"),
+            _make_event(hermits=["All"], title="Server Event"),
+        ]
+
+    def test_returns_list(self):
+        self.assertIsInstance(build_most_active_hermits(9, self._events()), list)
+
+    def test_top_n_limits(self):
+        result = build_most_active_hermits(9, self._events(), top_n=2)
+        self.assertLessEqual(len(result), 2)
+
+    def test_grian_is_most_active(self):
+        result = build_most_active_hermits(9, self._events(), top_n=5)
+        self.assertEqual(result[0]["hermit"], "Grian")
+
+    def test_grian_event_count_is_3(self):
+        result = build_most_active_hermits(9, self._events(), top_n=5)
+        grian = next(r for r in result if r["hermit"] == "Grian")
+        self.assertEqual(grian["event_count"], 3)
+
+    def test_all_excluded(self):
+        result = build_most_active_hermits(9, self._events(), top_n=10)
+        names = [r["hermit"] for r in result]
+        self.assertNotIn("All", names)
+
+    def test_ranks_sequential(self):
+        result = build_most_active_hermits(9, self._events(), top_n=5)
+        for i, entry in enumerate(result, start=1):
+            self.assertEqual(entry["rank"], i)
+
+    def test_required_keys(self):
+        required = {"rank", "hermit", "event_count"}
+        for entry in build_most_active_hermits(9, self._events(), top_n=5):
+            self.assertTrue(required.issubset(entry.keys()))
+
+    def test_sorted_by_count_desc(self):
+        result = build_most_active_hermits(9, self._events(), top_n=5)
+        counts = [r["event_count"] for r in result]
+        self.assertEqual(counts, sorted(counts, reverse=True))
+
+    def test_empty_events_returns_empty(self):
+        self.assertEqual(build_most_active_hermits(9, []), [])
+
+    def test_only_all_events_returns_empty(self):
+        events = [_make_event(hermits=["All"]) for _ in range(3)]
+        self.assertEqual(build_most_active_hermits(9, events), [])
+
+    def test_default_top_n_is_5(self):
+        events = [_make_event(hermits=[f"Hermit{i}"]) for i in range(10)]
+        result = build_most_active_hermits(9, events)
+        self.assertLessEqual(len(result), 5)
+
+    def test_event_count_is_int(self):
+        result = build_most_active_hermits(9, self._events(), top_n=5)
+        for entry in result:
+            self.assertIsInstance(entry["event_count"], int)
+
+
+# ---------------------------------------------------------------------------
+# build_notable_builds
+# ---------------------------------------------------------------------------
+
+class TestBuildNotableBuilds(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(type="build", title="Epic Base", hermits=["Grian", "Scar"],
+                        date_precision="day"),
+            _make_event(type="build", title="Small Hut", hermits=["Mumbo"]),
+            _make_event(type="build", title="Mega Farm", hermits=["A", "B", "C", "D"]),
+            _make_event(type="milestone", title="Season Start", hermits=["All"]),
+            _make_event(type="lore", title="Lore Event", hermits=["Grian"]),
+        ]
+
+    def test_returns_list(self):
+        self.assertIsInstance(build_notable_builds(9, self._events()), list)
+
+    def test_top_n_limits(self):
+        self.assertLessEqual(len(build_notable_builds(9, self._events(), top_n=2)), 2)
+
+    def test_only_build_events(self):
+        result = build_notable_builds(9, self._events(), top_n=10)
+        # No milestone or lore events should be present
+        titles = [r["title"] for r in result]
+        self.assertNotIn("Season Start", titles)
+        self.assertNotIn("Lore Event", titles)
+
+    def test_sorted_by_score_desc(self):
+        result = build_notable_builds(9, self._events(), top_n=3)
+        scores = [r["significance_score"] for r in result]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_ranks_sequential(self):
+        result = build_notable_builds(9, self._events(), top_n=3)
+        for i, entry in enumerate(result, start=1):
+            self.assertEqual(entry["rank"], i)
+
+    def test_required_keys(self):
+        required = {"rank", "title", "description", "date", "hermits",
+                    "significance_score"}
+        for entry in build_notable_builds(9, self._events(), top_n=3):
+            self.assertTrue(required.issubset(entry.keys()))
+
+    def test_empty_events_returns_empty(self):
+        self.assertEqual(build_notable_builds(9, []), [])
+
+    def test_no_build_events_returns_empty(self):
+        events = [_make_event(type="milestone"), _make_event(type="lore")]
+        self.assertEqual(build_notable_builds(9, events), [])
+
+    def test_hermits_is_list(self):
+        result = build_notable_builds(9, self._events(), top_n=3)
+        for entry in result:
+            self.assertIsInstance(entry["hermits"], list)
+
+    def test_score_is_int(self):
+        result = build_notable_builds(9, self._events(), top_n=3)
+        for entry in result:
+            self.assertIsInstance(entry["significance_score"], int)
+
+    def test_default_top_n_is_3(self):
+        events = [_make_event(type="build", title=f"Build {i}") for i in range(10)]
+        result = build_notable_builds(9, events)
+        self.assertLessEqual(len(result), 3)
+
+
+# ---------------------------------------------------------------------------
+# build_digest — new keys
+# ---------------------------------------------------------------------------
+
+class TestBuildDigestNewKeys(unittest.TestCase):
+
+    def test_most_active_hermits_present(self):
+        d = build_digest(9)
+        self.assertIn("most_active_hermits", d)
+
+    def test_notable_builds_present(self):
+        d = build_digest(9)
+        self.assertIn("notable_builds", d)
+
+    def test_most_active_hermits_is_list(self):
+        self.assertIsInstance(build_digest(9)["most_active_hermits"], list)
+
+    def test_notable_builds_is_list(self):
+        self.assertIsInstance(build_digest(9)["notable_builds"], list)
+
+    def test_most_active_hermits_entries_have_rank(self):
+        for entry in build_digest(9)["most_active_hermits"]:
+            self.assertIn("rank", entry)
+
+    def test_notable_builds_entries_have_rank(self):
+        for entry in build_digest(9)["notable_builds"]:
+            self.assertIn("rank", entry)
+
+    def test_json_serialisable_with_new_keys(self):
+        import json
+        d = build_digest(9)
+        serialised = json.dumps(d)
+        self.assertIsInstance(serialised, str)
+
+    def test_sparse_season_no_crash(self):
+        d = build_digest(1)
+        self.assertIn("most_active_hermits", d)
+        self.assertIn("notable_builds", d)
+
+
+# ---------------------------------------------------------------------------
+# render_markdown — new sections
+# ---------------------------------------------------------------------------
+
+class TestRenderMarkdownNewSections(unittest.TestCase):
+
+    def _digest(self):
+        return build_digest(9, top_n=3)
+
+    def test_has_most_active_section(self):
+        self.assertIn("## Most Active Hermits", render_markdown(self._digest()))
+
+    def test_has_notable_builds_section(self):
+        self.assertIn("## Notable Builds", render_markdown(self._digest()))
+
+    def test_empty_active_no_crash(self):
+        d = self._digest()
+        d["most_active_hermits"] = []
+        md = render_markdown(d)
+        self.assertIsInstance(md, str)
+        self.assertIn("Most Active Hermits", md)
+
+    def test_empty_builds_no_crash(self):
+        d = self._digest()
+        d["notable_builds"] = []
+        md = render_markdown(d)
+        self.assertIsInstance(md, str)
+        self.assertIn("Notable Builds", md)
+
+    def test_word_count_under_800(self):
+        md = render_markdown(self._digest())
+        # Strip markdown punctuation then count words
+        import re
+        plain = re.sub(r"[#*>`\-_]", " ", md)
+        word_count = len(plain.split())
+        self.assertLessEqual(
+            word_count, 800,
+            f"Digest markdown exceeds 800 words: {word_count} words",
+        )
+
+    def test_active_hermit_name_in_output(self):
+        d = self._digest()
+        if d["most_active_hermits"]:
+            top_hermit = d["most_active_hermits"][0]["hermit"]
+            self.assertIn(top_hermit, render_markdown(d))
+
+    def test_notable_build_title_in_output(self):
+        d = self._digest()
+        if d["notable_builds"]:
+            top_build_title = d["notable_builds"][0]["title"]
+            self.assertIn(top_build_title, render_markdown(d))
+
+
+# ---------------------------------------------------------------------------
+# Discord embed — new fields
+# ---------------------------------------------------------------------------
+
+class TestDiscordEmbedNewFields(unittest.TestCase):
+
+    def _embed(self, season: int = 9) -> dict:
+        return build_discord_embed(build_digest(season))
+
+    def test_most_active_field_present(self):
+        names = [f["name"] for f in self._embed()["fields"]]
+        self.assertTrue(any("Active" in n for n in names),
+                        f"No 'Active' field in: {names}")
+
+    def test_limits_still_hold_with_new_fields(self):
+        embed = self._embed()
+        total = len(embed.get("title", ""))
+        for f in embed.get("fields", []):
+            self.assertLessEqual(len(f["value"]), _DISCORD_FIELD_VALUE_LIMIT,
+                                 f"Field '{f['name']}' over limit")
+            total += len(f.get("name", "")) + len(f.get("value", ""))
+        total += len(embed.get("footer", {}).get("text", ""))
+        self.assertLessEqual(total, _DISCORD_EMBED_TOTAL_LIMIT)
+
+    def test_all_seasons_limits_hold(self):
+        for s in KNOWN_SEASONS:
+            embed = self._embed(s)
+            for f in embed["fields"]:
+                self.assertLessEqual(
+                    len(f["value"]), _DISCORD_FIELD_VALUE_LIMIT,
+                    f"Season {s} field '{f['name']}' over limit",
+                )
+            total = len(embed.get("title", ""))
+            for f in embed.get("fields", []):
+                total += len(f.get("name", "")) + len(f.get("value", ""))
+            total += len(embed.get("footer", {}).get("text", ""))
+            self.assertLessEqual(total, _DISCORD_EMBED_TOTAL_LIMIT,
+                                 f"Season {s} total embed over limit")
+
+    def test_empty_active_no_crash(self):
+        digest = build_digest(9)
+        digest["most_active_hermits"] = []
+        embed = build_discord_embed(digest)
+        self.assertIsInstance(embed, dict)
+
+    def test_empty_builds_no_crash(self):
+        digest = build_digest(9)
+        digest["notable_builds"] = []
+        embed = build_discord_embed(digest)
+        self.assertIsInstance(embed, dict)
 
 
 if __name__ == "__main__":

--- a/tools/season_digest.py
+++ b/tools/season_digest.py
@@ -264,6 +264,61 @@ def build_collaborations(season: int, events: list[dict], top_n: int) -> list[di
     return results
 
 
+def build_most_active_hermits(
+    season: int, events: list[dict], top_n: int = 5
+) -> list[dict]:
+    """
+    Return the *top_n* most frequently appearing hermits in *events*.
+
+    "All" entries are excluded — only named hermits are counted.
+
+    Each entry: rank, hermit, event_count
+    """
+    counter: collections.Counter = collections.Counter()
+    for ev in events:
+        for h in ev.get("hermits", []):
+            if h != "All":
+                counter[h] += 1
+
+    results: list[dict] = []
+    for rank, (hermit, count) in enumerate(counter.most_common(top_n), start=1):
+        results.append({"rank": rank, "hermit": hermit, "event_count": count})
+    return results
+
+
+def build_notable_builds(
+    season: int, events: list[dict], top_n: int = 3
+) -> list[dict]:
+    """
+    Return the *top_n* most significant build events for *season*.
+
+    Only events with ``type == "build"`` are considered; they are ranked by
+    the same significance score used elsewhere in the digest.
+
+    Each entry: rank, title, description, date, hermits, significance_score
+    """
+    build_events = [ev for ev in events if ev.get("type") == "build"]
+    scored = [
+        (_significance_score(ev), _event_sort_key(ev), ev)
+        for ev in build_events
+    ]
+    scored.sort(key=lambda x: (-x[0], x[1]))
+
+    results: list[dict] = []
+    for rank, (score, _, ev) in enumerate(scored[:top_n], start=1):
+        results.append(
+            {
+                "rank": rank,
+                "title": ev.get("title", "(untitled)"),
+                "description": ev.get("description", ""),
+                "date": ev.get("date", ""),
+                "hermits": ev.get("hermits", []),
+                "significance_score": score,
+            }
+        )
+    return results
+
+
 def build_arc_summary(season: int, stats: dict, highlights: list[dict]) -> str:
     """
     One-paragraph narrative arc synthesised from milestone/lore highlights.
@@ -317,16 +372,23 @@ def build_arc_summary(season: int, stats: dict, highlights: list[dict]) -> str:
 # Digest assembler
 # ---------------------------------------------------------------------------
 
+_DEFAULT_TOP_ACTIVE = 5
+_DEFAULT_TOP_BUILDS = 3
+
+
 def build_digest(
     season: int,
     top_n: int = _DEFAULT_TOP_N,
     top_pairs: int = _DEFAULT_TOP_PAIRS,
+    top_active: int = _DEFAULT_TOP_ACTIVE,
+    top_builds: int = _DEFAULT_TOP_BUILDS,
 ) -> dict:
     """
     Assemble a full Season in Review digest for *season*.
 
     Returns a structured dict with keys:
-        season, stats, highlights, peak_moment, collaborations, arc_summary
+        season, stats, highlights, peak_moment, collaborations, arc_summary,
+        most_active_hermits, notable_builds
 
     Never raises for known seasons with sparse data — sections will be empty
     rather than absent.
@@ -339,6 +401,8 @@ def build_digest(
     peak = build_peak_moment(season, events)
     collabs = build_collaborations(season, events, top_pairs)
     arc = build_arc_summary(season, stats, highlights)
+    active = build_most_active_hermits(season, events, top_active)
+    builds = build_notable_builds(season, events, top_builds)
 
     return {
         "season": season,
@@ -347,6 +411,8 @@ def build_digest(
         "peak_moment": peak,
         "collaborations": collabs,
         "arc_summary": arc,
+        "most_active_hermits": active,
+        "notable_builds": builds,
     }
 
 
@@ -370,6 +436,8 @@ def render_markdown(digest: dict) -> str:
     peak = digest.get("peak_moment")
     collabs = digest.get("collaborations", [])
     arc = digest.get("arc_summary", "")
+    active = digest.get("most_active_hermits", [])
+    builds = digest.get("notable_builds", [])
 
     lines: list[str] = []
 
@@ -435,6 +503,42 @@ def render_markdown(digest: dict) -> str:
             lines.append("")
     else:
         lines.append("*No highlights data available for this season.*")
+        lines.append("")
+
+    # ── Most active hermits ─────────────────────────────────────────────────
+    lines += ["## Most Active Hermits", ""]
+    if active:
+        for entry in active:
+            rank = entry["rank"]
+            hermit = entry["hermit"]
+            count = entry["event_count"]
+            plural = "s" if count != 1 else ""
+            lines.append(f"{rank}. **{hermit}** — {count} event{plural}")
+        lines.append("")
+    else:
+        lines.append("*No hermit activity data available for this season.*")
+        lines.append("")
+
+    # ── Notable builds ─────────────────────────────────────────────────────
+    lines += ["## Notable Builds", ""]
+    if builds:
+        for entry in builds:
+            rank = entry["rank"]
+            title = entry["title"]
+            desc = entry.get("description", "")
+            date = entry.get("date", "")
+            hermits = entry.get("hermits", [])
+            score = entry.get("significance_score", 0)
+
+            lines.append(f"### {rank}. {title}")
+            meta_parts = [p for p in [date, _md_hermits(hermits),
+                                      f"score: {score}"] if p]
+            lines.append(f"*{' · '.join(meta_parts)}*")
+            if desc:
+                lines += ["", desc]
+            lines.append("")
+    else:
+        lines.append("*No notable build events recorded for this season.*")
         lines.append("")
 
     # ── Collaborations ─────────────────────────────────────────────────────
@@ -586,6 +690,37 @@ def _discord_collabs_value(collabs: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _discord_active_value(active: list[dict]) -> str:
+    """Numbered list of most active hermits."""
+    if not active:
+        return "*No hermit activity data available.*"
+    lines: list[str] = []
+    for entry in active:
+        line = f"{entry['rank']}. **{entry['hermit']}** — {entry['event_count']} event{'s' if entry['event_count'] != 1 else ''}"
+        candidate = "\n".join(lines + [line])
+        if len(candidate) > _DISCORD_FIELD_VALUE_LIMIT - 4:
+            lines.append(" …")
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _discord_builds_value(builds: list[dict]) -> str:
+    """Numbered list of notable builds."""
+    if not builds:
+        return "*No notable build events recorded.*"
+    lines: list[str] = []
+    for entry in builds:
+        hermit_str = _md_hermits(entry.get("hermits", []))
+        line = f"{entry['rank']}. **{entry['title']}** — {hermit_str}"
+        candidate = "\n".join(lines + [line])
+        if len(candidate) > _DISCORD_FIELD_VALUE_LIMIT - 4:
+            lines.append(" …")
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+
 def build_discord_embed(digest: dict) -> dict:
     """
     Build a Discord embed dict from *digest*.
@@ -603,11 +738,13 @@ def build_discord_embed(digest: dict) -> dict:
             "title":  "🏆 Hermitcraft Season N — Season in Review",
             "color":  <int>,
             "fields": [
-                {"name": "📊 Quick Stats",         "value": "…", "inline": False},
-                {"name": "📖 Season Arc",           "value": "…", "inline": False},
-                {"name": "🌟 Peak Moment",          "value": "…", "inline": False},
-                {"name": "🏅 Top Highlights",       "value": "…", "inline": False},
-                {"name": "🤝 Notable Collaborations","value": "…", "inline": False},
+                {"name": "📊 Quick Stats",           "value": "…", "inline": False},
+                {"name": "📖 Season Arc",             "value": "…", "inline": False},
+                {"name": "🌟 Peak Moment",            "value": "…", "inline": False},
+                {"name": "🏅 Top Highlights",         "value": "…", "inline": False},
+                {"name": "🏃 Most Active Hermits",    "value": "…", "inline": False},
+                {"name": "🏗️ Notable Builds",        "value": "…", "inline": False},
+                {"name": "🤝 Notable Collaborations", "value": "…", "inline": False},
             ],
             "footer": {"text": "hermitcraft-agent • /digest season N"},
         }
@@ -618,6 +755,8 @@ def build_discord_embed(digest: dict) -> dict:
     peak = digest.get("peak_moment")
     collabs = digest.get("collaborations", [])
     arc = digest.get("arc_summary", "")
+    active = digest.get("most_active_hermits", [])
+    builds = digest.get("notable_builds", [])
 
     title = _truncate(
         f"🏆 Hermitcraft Season {season} — Season in Review",
@@ -659,6 +798,25 @@ def build_discord_embed(digest: dict) -> dict:
             {
                 "name": f"🏅 Top {len(highlights)} Highlights",
                 "value": _discord_highlights_value(highlights),
+                "inline": False,
+            }
+        )
+
+    fields.append(
+        {
+            "name": "🏃 Most Active Hermits",
+            "value": _truncate(_discord_active_value(active),
+                               _DISCORD_FIELD_VALUE_LIMIT),
+            "inline": False,
+        }
+    )
+
+    if builds:
+        fields.append(
+            {
+                "name": "🏗️ Notable Builds",
+                "value": _truncate(_discord_builds_value(builds),
+                                   _DISCORD_FIELD_VALUE_LIMIT),
                 "inline": False,
             }
         )


### PR DESCRIPTION
## Summary

- Added `build_most_active_hermits()` — ranks hermits by event appearance count (excludes "All" entries), returned as `most_active_hermits` key in digest dict
- Added `build_notable_builds()` — surfaces top build-type events ranked by significance score, returned as `notable_builds` key in digest dict  
- Both sections integrated into `render_markdown()` as `## Most Active Hermits` and `## Notable Builds` headers
- Discord embed gains a `🏃 Most Active Hermits` field; `🏗️ Notable Builds` field added when data exists
- 43 new tests; total test count: 186 (all green)
- Season 9 digest word count: ~408 words (under 800-word limit)

## Test plan

- [x] Run `python3 -m unittest tests.test_season_digest` — 186 tests pass
- [x] `python3 -m tools.season_digest --season 9` produces markdown with all 7 sections
- [x] `python3 -m tools.season_digest --season 9 --json` includes `most_active_hermits` and `notable_builds` keys
- [x] `python3 -m tools.season_digest --season 9 --discord` embed stays within Discord limits
- [x] Sparse season (S1) produces output without crashing

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)