### PR TITLE
[hermitcraft-agent] feat: add GET /seasons/:id/vs/:id2 head-to-head season comparison

### DIFF
--- a/tests/test_season_vs.py
+++ b/tests/test_season_vs.py
@@ -1,0 +1,482 @@
+"""
+Tests for tools/season_vs.py
+"""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.season_vs import (
+    KNOWN_SEASONS,
+    _significance_score,
+    _dim_winner,
+    _event_count,
+    _member_count,
+    _build_count,
+    _collab_count,
+    _highlight_score,
+    build_vs,
+    render_text,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(argv: list[str]) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        try:
+            rc = main(argv)
+        except SystemExit as e:
+            rc = int(e.code) if e.code is not None else 0
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _make_event(**kw) -> dict:
+    base = {
+        "season": 9,
+        "type": "milestone",
+        "title": "Test",
+        "description": "",
+        "date": "2022-01-01",
+        "date_precision": "month",
+        "hermits": ["Grian"],
+    }
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _significance_score
+# ---------------------------------------------------------------------------
+
+class TestSignificanceScore(unittest.TestCase):
+
+    def test_milestone_score(self):
+        self.assertEqual(_significance_score(_make_event(type="milestone")), 10)
+
+    def test_meta_score(self):
+        self.assertEqual(_significance_score(_make_event(type="meta")), 1)
+
+    def test_all_hermits_bonus(self):
+        self.assertEqual(_significance_score(_make_event(type="milestone", hermits=["All"])), 13)
+
+    def test_pair_bonus(self):
+        self.assertEqual(_significance_score(_make_event(type="build", hermits=["A", "B"])), 6)
+
+    def test_day_bonus(self):
+        self.assertEqual(_significance_score(
+            _make_event(type="build", hermits=["A"], date_precision="day")), 6)
+
+    def test_unknown_type_zero(self):
+        self.assertEqual(_significance_score(_make_event(type="xyzunknown")), 0)
+
+
+# ---------------------------------------------------------------------------
+# _dim_winner
+# ---------------------------------------------------------------------------
+
+class TestDimWinner(unittest.TestCase):
+
+    def test_a_wins(self):
+        self.assertEqual(_dim_winner(10, 5), "a")
+
+    def test_b_wins(self):
+        self.assertEqual(_dim_winner(3, 7), "b")
+
+    def test_tie(self):
+        self.assertEqual(_dim_winner(5, 5), "tie")
+
+    def test_zeros_tie(self):
+        self.assertEqual(_dim_winner(0, 0), "tie")
+
+
+# ---------------------------------------------------------------------------
+# Dimension extractors
+# ---------------------------------------------------------------------------
+
+class TestEventCount(unittest.TestCase):
+
+    def test_empty_is_zero(self):
+        self.assertEqual(_event_count([]), 0)
+
+    def test_counts_all(self):
+        events = [_make_event(), _make_event(), _make_event()]
+        self.assertEqual(_event_count(events), 3)
+
+
+class TestMemberCount(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(hermits=["Grian", "Scar"]),
+            _make_event(hermits=["Mumbo"]),
+            _make_event(hermits=["All"]),
+        ]
+
+    def test_excludes_all(self):
+        result = _member_count(self._events())
+        self.assertEqual(result, 3)  # Grian, Scar, Mumbo
+
+    def test_deduplicates(self):
+        events = [_make_event(hermits=["Grian"]), _make_event(hermits=["Grian"])]
+        self.assertEqual(_member_count(events), 1)
+
+    def test_empty_is_zero(self):
+        self.assertEqual(_member_count([]), 0)
+
+
+class TestBuildCount(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(type="build"),
+            _make_event(type="build"),
+            _make_event(type="milestone"),
+        ]
+
+    def test_counts_build_events(self):
+        self.assertEqual(_build_count(self._events(), []), 2)
+
+    def test_adds_major_builds(self):
+        self.assertEqual(_build_count(self._events(), ["Build A", "Build B"]), 4)
+
+    def test_empty_is_zero(self):
+        self.assertEqual(_build_count([], []), 0)
+
+    def test_non_build_types_excluded(self):
+        events = [_make_event(type="milestone"), _make_event(type="lore")]
+        self.assertEqual(_build_count(events, []), 0)
+
+
+class TestCollabCount(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(hermits=["Grian", "Scar"]),       # collab
+            _make_event(hermits=["Grian", "Scar", "Mumbo"]),  # collab
+            _make_event(hermits=["Solo"]),                  # not collab
+            _make_event(hermits=["All"]),                   # not collab (All)
+        ]
+
+    def test_counts_two_or_more(self):
+        self.assertEqual(_collab_count(self._events()), 2)
+
+    def test_all_excluded(self):
+        events = [_make_event(hermits=["All"])]
+        self.assertEqual(_collab_count(events), 0)
+
+    def test_solo_excluded(self):
+        events = [_make_event(hermits=["Grian"])]
+        self.assertEqual(_collab_count(events), 0)
+
+    def test_empty_is_zero(self):
+        self.assertEqual(_collab_count([]), 0)
+
+
+class TestHighlightScore(unittest.TestCase):
+
+    def _events(self):
+        return [
+            _make_event(type="milestone", hermits=["All"]),   # score 13
+            _make_event(type="lore", hermits=["Grian"]),       # score 8
+            _make_event(type="meta", hermits=["Grian"]),       # score 1
+        ]
+
+    def test_sum_of_top_n(self):
+        # top 2: 13 + 8 = 21
+        self.assertEqual(_highlight_score(self._events(), top_n=2), 21)
+
+    def test_all_events(self):
+        # all 3: 13 + 8 + 1 = 22
+        self.assertEqual(_highlight_score(self._events(), top_n=3), 22)
+
+    def test_empty_is_zero(self):
+        self.assertEqual(_highlight_score([]), 0)
+
+    def test_top_n_caps(self):
+        events = [_make_event(type="milestone", hermits=["All"])] * 10
+        # only top 5 counted: 13 * 5 = 65
+        self.assertEqual(_highlight_score(events, top_n=5), 65)
+
+
+# ---------------------------------------------------------------------------
+# build_vs
+# ---------------------------------------------------------------------------
+
+class TestBuildVs(unittest.TestCase):
+
+    def _result(self, a=9, b=10):
+        return build_vs(a, b)
+
+    def test_returns_dict(self):
+        self.assertIsInstance(self._result(), dict)
+
+    def test_top_level_keys(self):
+        required = {"season_a", "season_b", "comparison", "winner",
+                    "winner_season", "rationale", "metadata"}
+        self.assertTrue(required.issubset(self._result().keys()))
+
+    def test_season_a_correct(self):
+        self.assertEqual(self._result()["season_a"], 9)
+
+    def test_season_b_correct(self):
+        self.assertEqual(self._result()["season_b"], 10)
+
+    def test_comparison_has_all_dimensions(self):
+        dims = self._result()["comparison"]
+        for key in ("event_count", "member_count", "build_count",
+                    "collab_count", "highlight_score"):
+            self.assertIn(key, dims)
+
+    def test_each_dimension_has_a_b_winner(self):
+        for dim, d in self._result()["comparison"].items():
+            self.assertIn("a", d, f"dim {dim} missing 'a'")
+            self.assertIn("b", d, f"dim {dim} missing 'b'")
+            self.assertIn("winner", d, f"dim {dim} missing 'winner'")
+
+    def test_dimension_winner_valid(self):
+        for dim, d in self._result()["comparison"].items():
+            self.assertIn(d["winner"], ("a", "b", "tie"))
+
+    def test_overall_winner_valid(self):
+        self.assertIn(self._result()["winner"], ("a", "b", "tie"))
+
+    def test_winner_season_is_int_or_none(self):
+        ws = self._result()["winner_season"]
+        self.assertTrue(ws is None or isinstance(ws, int))
+
+    def test_winner_season_matches_winner(self):
+        r = self._result()
+        if r["winner"] == "a":
+            self.assertEqual(r["winner_season"], 9)
+        elif r["winner"] == "b":
+            self.assertEqual(r["winner_season"], 10)
+        else:
+            self.assertIsNone(r["winner_season"])
+
+    def test_rationale_is_string(self):
+        self.assertIsInstance(self._result()["rationale"], str)
+
+    def test_rationale_nonempty(self):
+        self.assertGreater(len(self._result()["rationale"]), 0)
+
+    def test_metadata_has_a_and_b(self):
+        meta = self._result()["metadata"]
+        self.assertIn("a", meta)
+        self.assertIn("b", meta)
+
+    def test_metadata_has_season_key(self):
+        meta = self._result()["metadata"]
+        self.assertEqual(meta["a"]["season"], 9)
+        self.assertEqual(meta["b"]["season"], 10)
+
+    def test_json_serialisable(self):
+        self.assertIsInstance(json.dumps(self._result()), str)
+
+    def test_all_season_pairs_no_crash(self):
+        # Test a variety of pairs without full cross-product
+        pairs = [(1, 2), (7, 9), (9, 11), (5, 10), (3, 8)]
+        for a, b in pairs:
+            try:
+                result = build_vs(a, b)
+            except Exception as e:
+                self.fail(f"build_vs({a}, {b}) raised {e}")
+            self.assertIn("winner", result)
+
+    def test_symmetric_winner_flips(self):
+        """build_vs(9, 10) winner='a' ↔ build_vs(10, 9) winner='b'."""
+        r1 = build_vs(9, 10)
+        r2 = build_vs(10, 9)
+        if r1["winner"] == "a":
+            self.assertEqual(r2["winner"], "b")
+        elif r1["winner"] == "b":
+            self.assertEqual(r2["winner"], "a")
+        else:
+            self.assertEqual(r2["winner"], "tie")
+
+    def test_dimension_values_are_ints(self):
+        for dim, d in self._result()["comparison"].items():
+            self.assertIsInstance(d["a"], int, f"dim {dim}['a'] not int")
+            self.assertIsInstance(d["b"], int, f"dim {dim}['b'] not int")
+
+    def test_sparse_season_no_crash(self):
+        result = build_vs(1, 2)
+        self.assertIn("winner", result)
+
+    def test_rationale_contains_season_number(self):
+        r = self._result()
+        rationale = r["rationale"]
+        # Should mention at least one season number
+        self.assertTrue(
+            "9" in rationale or "10" in rationale or "tie" in rationale.lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# render_text
+# ---------------------------------------------------------------------------
+
+class TestRenderText(unittest.TestCase):
+
+    def _result(self):
+        return build_vs(9, 10)
+
+    def test_returns_string(self):
+        self.assertIsInstance(render_text(self._result()), str)
+
+    def test_contains_season_numbers(self):
+        text = render_text(self._result())
+        self.assertIn("9", text)
+        self.assertIn("10", text)
+
+    def test_contains_result_line(self):
+        text = render_text(self._result())
+        self.assertIn("RESULT", text)
+
+    def test_contains_dimension_labels(self):
+        text = render_text(self._result())
+        self.assertIn("Timeline events", text)
+        self.assertIn("Active hermits", text)
+
+    def test_contains_rationale(self):
+        r = self._result()
+        text = render_text(r)
+        # rationale is included verbatim
+        self.assertIn(r["rationale"], text)
+
+    def test_tie_shows_tie(self):
+        r = build_vs(9, 10)
+        r["winner"] = "tie"
+        r["winner_season"] = None
+        text = render_text(r)
+        self.assertIn("TIE", text)
+
+    def test_all_season_pairs_render(self):
+        for a, b in [(1, 2), (7, 9), (9, 11)]:
+            text = render_text(build_vs(a, b))
+            self.assertIsInstance(text, str)
+            self.assertGreater(len(text), 0)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCLI(unittest.TestCase):
+
+    def test_valid_pair_exits_0(self):
+        rc, _, _ = _run(["--a", "9", "--b", "10"])
+        self.assertEqual(rc, 0)
+
+    def test_list_exits_0(self):
+        rc, out, _ = _run(["--list"])
+        self.assertEqual(rc, 0)
+        self.assertIn("1", out)
+        self.assertIn("11", out)
+
+    def test_invalid_season_a_exits_1(self):
+        rc, _, err = _run(["--a", "999", "--b", "10"])
+        self.assertEqual(rc, 1)
+        self.assertIn("999", err)
+
+    def test_invalid_season_b_exits_1(self):
+        rc, _, err = _run(["--a", "9", "--b", "999"])
+        self.assertEqual(rc, 1)
+        self.assertIn("999", err)
+
+    def test_same_season_exits_1(self):
+        rc, _, err = _run(["--a", "9", "--b", "9"])
+        self.assertEqual(rc, 1)
+
+    def test_missing_b_exits_1(self):
+        rc, _, err = _run(["--a", "9"])
+        self.assertEqual(rc, 1)
+
+    def test_no_args_exits_nonzero(self):
+        rc, _, _ = _run([])
+        self.assertNotEqual(rc, 0)
+
+    def test_text_output_has_result(self):
+        _, out, _ = _run(["--a", "9", "--b", "10"])
+        self.assertIn("RESULT", out)
+
+    def test_json_valid(self):
+        rc, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIsInstance(data, dict)
+
+    def test_json_has_winner(self):
+        _, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        data = json.loads(out)
+        self.assertIn("winner", data)
+
+    def test_json_has_rationale(self):
+        _, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        data = json.loads(out)
+        self.assertIn("rationale", data)
+        self.assertIsInstance(data["rationale"], str)
+        self.assertGreater(len(data["rationale"]), 0)
+
+    def test_json_has_comparison(self):
+        _, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        data = json.loads(out)
+        self.assertIn("comparison", data)
+
+    def test_json_has_metadata(self):
+        _, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        data = json.loads(out)
+        self.assertIn("metadata", data)
+
+    def test_json_winner_valid_value(self):
+        _, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        data = json.loads(out)
+        self.assertIn(data["winner"], ("a", "b", "tie"))
+
+    def test_json_winner_season_9_10(self):
+        _, out, _ = _run(["--a", "9", "--b", "10", "--json"])
+        data = json.loads(out)
+        if data["winner"] in ("a", "b"):
+            self.assertIsNotNone(data["winner_season"])
+            self.assertIn(data["winner_season"], (9, 10))
+
+    def test_all_known_season_pairs_exit_0(self):
+        pairs = [(1, 11), (7, 9), (8, 10), (5, 6), (2, 4)]
+        for a, b in pairs:
+            rc, _, _ = _run(["--a", str(a), "--b", str(b)])
+            self.assertEqual(rc, 0, f"Pair ({a},{b}) exited nonzero")
+
+    def test_json_season_fields_correct(self):
+        _, out, _ = _run(["--a", "7", "--b", "9", "--json"])
+        data = json.loads(out)
+        self.assertEqual(data["season_a"], 7)
+        self.assertEqual(data["season_b"], 9)
+
+    def test_json_serialisable_all_pairs(self):
+        for a, b in [(9, 10), (7, 11), (1, 11)]:
+            _, out, _ = _run(["--a", str(a), "--b", str(b), "--json"])
+            data = json.loads(out)
+            self.assertIsInstance(data, dict)
+
+    def test_text_contains_dimension_names(self):
+        _, out, _ = _run(["--a", "9", "--b", "10"])
+        self.assertIn("Timeline events", out)
+        self.assertIn("Active hermits", out)
+        self.assertIn("Notable builds", out)
+
+    def test_sparse_season_pair_no_crash(self):
+        rc, _, _ = _run(["--a", "1", "--b", "2"])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/season_vs.py
+++ b/tools/season_vs.py
@@ -1,0 +1,492 @@
+"""
+tools/season_vs.py — Head-to-head season comparison for Hermitcraft.
+
+Implements the ``GET /seasons/:id/vs/:id2`` endpoint contract: compares two
+Hermitcraft seasons across multiple activity dimensions and declares a
+``winner`` with a brief rationale drawn from measurable metrics.
+
+Dimensions compared
+-------------------
+  event_count      Total timeline events documented
+  member_count     Named hermits on the roster
+  build_count      Documented major builds
+  collab_count     Events involving two or more named hermits
+  highlight_score  Sum of significance scores for the top-5 events
+
+Winner determination
+--------------------
+  Each dimension is scored as a simple win (1) or loss (0) for season A.
+  The season with more dimension wins is declared winner.  On a tie the
+  season with the higher highlight_score wins.  If still tied, it's a draw.
+
+Output modes
+------------
+  --text   (default)  Formatted side-by-side comparison table
+  --json              Structured dict for downstream tooling
+
+HTTP API contract
+-----------------
+  GET /seasons/:id/vs/:id2
+      Path params: id, id2  — season numbers (1–11)
+      Response (JSON):
+          {
+              "season_a": <int>,
+              "season_b": <int>,
+              "comparison": {
+                  "event_count":     {"a": <int>, "b": <int>, "winner": "a"|"b"|"tie"},
+                  "member_count":    {"a": <int>, "b": <int>, "winner": "a"|"b"|"tie"},
+                  "build_count":     {"a": <int>, "b": <int>, "winner": "a"|"b"|"tie"},
+                  "collab_count":    {"a": <int>, "b": <int>, "winner": "a"|"b"|"tie"},
+                  "highlight_score": {"a": <int>, "b": <int>, "winner": "a"|"b"|"tie"},
+              },
+              "winner": "a"|"b"|"tie",
+              "winner_season": <int>|null,
+              "rationale": "<one-sentence explanation>",
+              "metadata": {
+                  "a": {"season": <int>, "duration": "...", "minecraft_version": "..."},
+                  "b": {"season": <int>, "duration": "...", "minecraft_version": "..."},
+              }
+          }
+      404 (exit 1): if either season number is out of range (1–11)
+
+Usage
+-----
+    python -m tools.season_vs --a 9 --b 10
+    python -m tools.season_vs --a 7 --b 9 --json
+    python -m tools.season_vs --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths / constants
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+_EVENTS_FILE = _REPO_ROOT / "knowledge" / "timelines" / "events.json"
+_VIDEO_EVENTS_FILE = _REPO_ROOT / "knowledge" / "timelines" / "video_events.json"
+
+KNOWN_SEASONS: list[int] = list(range(1, 12))  # seasons 1–11
+
+# ---------------------------------------------------------------------------
+# Significance scoring (local copy — avoids circular imports)
+# ---------------------------------------------------------------------------
+
+_TYPE_SCORE: dict[str, int] = {
+    "milestone": 10,
+    "lore": 8,
+    "game": 7,
+    "collab": 6,
+    "build": 5,
+    "meta": 1,
+}
+
+
+def _significance_score(event: dict) -> int:
+    score = _TYPE_SCORE.get(event.get("type", ""), 0)
+    hermits = event.get("hermits", [])
+    if hermits == ["All"]:
+        score += 3
+    elif len(hermits) >= 4:
+        score += 2
+    elif len(hermits) >= 2:
+        score += 1
+    if event.get("date_precision") == "day":
+        score += 1
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Event loading
+# ---------------------------------------------------------------------------
+
+def _load_all_events() -> list[dict]:
+    events: list[dict] = []
+    for path in (_EVENTS_FILE, _VIDEO_EVENTS_FILE):
+        if path.exists():
+            try:
+                events.extend(json.loads(path.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                pass
+    return events
+
+
+def _season_events(all_events: list[dict], season: int) -> list[dict]:
+    return [ev for ev in all_events if ev.get("season") == season]
+
+
+# ---------------------------------------------------------------------------
+# Season metadata (from season_recap)
+# ---------------------------------------------------------------------------
+
+def _load_season_meta(season: int) -> dict:
+    """Pull lightweight metadata for *season* from season_recap."""
+    try:
+        from tools.season_recap import build_recap  # type: ignore
+        recap = build_recap(season)
+        return {
+            "season": season,
+            "duration": recap.get("duration", ""),
+            "minecraft_version": recap.get("minecraft_version", ""),
+            "member_count_from_recap": recap.get("member_count", 0),
+            "major_builds": recap.get("major_builds", []),
+        }
+    except Exception:
+        return {
+            "season": season,
+            "duration": "",
+            "minecraft_version": "",
+            "member_count_from_recap": 0,
+            "major_builds": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Dimension extractors
+# ---------------------------------------------------------------------------
+
+def _event_count(events: list[dict]) -> int:
+    return len(events)
+
+
+def _member_count(events: list[dict]) -> int:
+    """Unique named hermits (excluding 'All') seen across events."""
+    hermit_set: set[str] = set()
+    for ev in events:
+        for h in ev.get("hermits", []):
+            if h != "All":
+                hermit_set.add(h)
+    return len(hermit_set)
+
+
+def _build_count(events: list[dict], major_builds: list) -> int:
+    """Build events from timeline + major_builds from recap."""
+    timeline_builds = sum(1 for ev in events if ev.get("type") == "build")
+    return timeline_builds + len(major_builds)
+
+
+def _collab_count(events: list[dict]) -> int:
+    """Events involving two or more named hermits (excluding 'All' catchall)."""
+    count = 0
+    for ev in events:
+        hermits = ev.get("hermits", [])
+        if hermits == ["All"]:
+            continue
+        named = [h for h in hermits if h != "All"]
+        if len(named) >= 2:
+            count += 1
+    return count
+
+
+def _highlight_score(events: list[dict], top_n: int = 5) -> int:
+    """Sum of significance scores for the top *top_n* events."""
+    scored = sorted(events, key=_significance_score, reverse=True)
+    return sum(_significance_score(ev) for ev in scored[:top_n])
+
+
+# ---------------------------------------------------------------------------
+# Comparison builder
+# ---------------------------------------------------------------------------
+
+def _dim_winner(a_val: int, b_val: int) -> str:
+    if a_val > b_val:
+        return "a"
+    if b_val > a_val:
+        return "b"
+    return "tie"
+
+
+def build_vs(season_a: int, season_b: int) -> dict:
+    """
+    Build a full head-to-head comparison between *season_a* and *season_b*.
+
+    Returns the structured dict matching the HTTP API contract (see module
+    docstring).  Never raises for valid season numbers with sparse data —
+    dimensions will be 0 rather than absent.
+    """
+    all_events = _load_all_events()
+    events_a = _season_events(all_events, season_a)
+    events_b = _season_events(all_events, season_b)
+
+    meta_a = _load_season_meta(season_a)
+    meta_b = _load_season_meta(season_b)
+
+    # Compute each dimension
+    dims: dict[str, dict[str, int | str]] = {}
+
+    ec_a = _event_count(events_a)
+    ec_b = _event_count(events_b)
+    dims["event_count"] = {"a": ec_a, "b": ec_b, "winner": _dim_winner(ec_a, ec_b)}
+
+    mc_a = _member_count(events_a) or meta_a["member_count_from_recap"]
+    mc_b = _member_count(events_b) or meta_b["member_count_from_recap"]
+    dims["member_count"] = {"a": mc_a, "b": mc_b, "winner": _dim_winner(mc_a, mc_b)}
+
+    bc_a = _build_count(events_a, meta_a["major_builds"])
+    bc_b = _build_count(events_b, meta_b["major_builds"])
+    dims["build_count"] = {"a": bc_a, "b": bc_b, "winner": _dim_winner(bc_a, bc_b)}
+
+    cc_a = _collab_count(events_a)
+    cc_b = _collab_count(events_b)
+    dims["collab_count"] = {"a": cc_a, "b": cc_b, "winner": _dim_winner(cc_a, cc_b)}
+
+    hs_a = _highlight_score(events_a)
+    hs_b = _highlight_score(events_b)
+    dims["highlight_score"] = {"a": hs_a, "b": hs_b, "winner": _dim_winner(hs_a, hs_b)}
+
+    # Tally wins
+    wins_a = sum(1 for d in dims.values() if d["winner"] == "a")
+    wins_b = sum(1 for d in dims.values() if d["winner"] == "b")
+
+    if wins_a > wins_b:
+        overall_winner = "a"
+        winner_season: int | None = season_a
+    elif wins_b > wins_a:
+        overall_winner = "b"
+        winner_season = season_b
+    else:
+        # Tie-break: higher highlight_score
+        if hs_a > hs_b:
+            overall_winner = "a"
+            winner_season = season_a
+        elif hs_b > hs_a:
+            overall_winner = "b"
+            winner_season = season_b
+        else:
+            overall_winner = "tie"
+            winner_season = None
+
+    rationale = _build_rationale(
+        season_a, season_b, overall_winner, wins_a, wins_b, dims
+    )
+
+    return {
+        "season_a": season_a,
+        "season_b": season_b,
+        "comparison": dims,
+        "winner": overall_winner,
+        "winner_season": winner_season,
+        "rationale": rationale,
+        "metadata": {
+            "a": {
+                "season": season_a,
+                "duration": meta_a["duration"],
+                "minecraft_version": meta_a["minecraft_version"],
+            },
+            "b": {
+                "season": season_b,
+                "duration": meta_b["duration"],
+                "minecraft_version": meta_b["minecraft_version"],
+            },
+        },
+    }
+
+
+def _build_rationale(
+    season_a: int,
+    season_b: int,
+    winner: str,
+    wins_a: int,
+    wins_b: int,
+    dims: dict,
+) -> str:
+    """One sentence explaining why the winner won (or why it's a tie)."""
+    if winner == "tie":
+        return (
+            f"Season {season_a} and Season {season_b} are evenly matched "
+            f"across all measured dimensions — too close to call."
+        )
+
+    win_season = season_a if winner == "a" else season_b
+    lose_season = season_b if winner == "a" else season_a
+    w = winner  # "a" or "b"
+
+    # Identify which dims the winner won
+    won_dims = [name for name, d in dims.items() if d["winner"] == w]
+    # Build human-readable dim labels
+    _dim_labels = {
+        "event_count": "documented events",
+        "member_count": "active hermits",
+        "build_count": "notable builds",
+        "collab_count": "collaboration events",
+        "highlight_score": "highlight significance",
+    }
+
+    if not won_dims:
+        return (
+            f"Season {win_season} edges out Season {lose_season} via tie-break "
+            f"on highlight significance score."
+        )
+
+    top_dim = won_dims[0]
+    top_val_w = dims[top_dim][w]
+    top_val_other = dims[top_dim]["b" if w == "a" else "a"]
+    label = _dim_labels.get(top_dim, top_dim.replace("_", " "))
+
+    wins_str = f"{max(wins_a, wins_b)}/{len(dims)}"
+    return (
+        f"Season {win_season} wins {wins_str} dimensions, leading most clearly "
+        f"in {label} ({top_val_w} vs {top_val_other})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Text renderer
+# ---------------------------------------------------------------------------
+
+def render_text(result: dict) -> str:
+    """Format the comparison as a human-readable table."""
+    sa = result["season_a"]
+    sb = result["season_b"]
+    dims = result["comparison"]
+    winner = result["winner"]
+    winner_season = result.get("winner_season")
+    rationale = result["rationale"]
+    meta = result["metadata"]
+
+    lines: list[str] = []
+    lines.append("=" * 64)
+    lines.append(f"  Season {sa}  vs  Season {sb}")
+    lines.append("=" * 64)
+
+    # Metadata row
+    for key in ("a", "b"):
+        s = sa if key == "a" else sb
+        m = meta[key]
+        dur = f"  {m['duration']}" if m.get("duration") else ""
+        ver = f"  [{m['minecraft_version']}]" if m.get("minecraft_version") else ""
+        lines.append(f"  S{s}:{dur}{ver}")
+    lines.append("")
+
+    # Dimension table
+    _dim_labels = {
+        "event_count": "Timeline events",
+        "member_count": "Active hermits",
+        "build_count": "Notable builds",
+        "collab_count": "Collaboration events",
+        "highlight_score": "Highlight score (top 5)",
+    }
+
+    col_w = 24
+    lines.append(f"  {'Dimension':<{col_w}}  {'S'+str(sa):>6}  {'S'+str(sb):>6}  Winner")
+    lines.append("  " + "-" * 56)
+
+    for dim_key, label in _dim_labels.items():
+        d = dims.get(dim_key, {})
+        val_a = d.get("a", 0)
+        val_b = d.get("b", 0)
+        dim_winner = d.get("winner", "tie")
+        w_label = (
+            f"S{sa}" if dim_winner == "a"
+            else f"S{sb}" if dim_winner == "b"
+            else "tie"
+        )
+        lines.append(
+            f"  {label:<{col_w}}  {val_a:>6}  {val_b:>6}  {w_label}"
+        )
+
+    lines.append("")
+
+    # Overall result
+    if winner == "tie":
+        lines.append("  RESULT: TIE")
+    else:
+        lines.append(f"  RESULT: Season {winner_season} wins")
+
+    lines.append(f"  {rationale}")
+    lines.append("=" * 64)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m tools.season_vs",
+        description=(
+            "Compare two Hermitcraft seasons head-to-head across event count, "
+            "hermit count, builds, collaborations, and highlight significance. "
+            "Declares a winner with a brief rationale."
+        ),
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--a",
+        type=int,
+        metavar="SEASON_A",
+        dest="season_a",
+        help="First season number (1–11)",
+    )
+    mode.add_argument(
+        "--list",
+        action="store_true",
+        help="List valid season numbers and exit",
+    )
+    p.add_argument(
+        "--b",
+        type=int,
+        metavar="SEASON_B",
+        dest="season_b",
+        help="Second season number (1–11) — required when --a is given",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON instead of formatted text",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print("Valid seasons:", ", ".join(str(s) for s in KNOWN_SEASONS))
+        return 0
+
+    season_a: int = args.season_a
+    season_b: int | None = args.season_b
+
+    # Validate both seasons provided
+    if season_b is None:
+        print("[season_vs] --b SEASON_B is required when --a is given.",
+              file=sys.stderr)
+        return 1
+
+    # Validate range
+    bad = [s for s in (season_a, season_b) if s not in KNOWN_SEASONS]
+    if bad:
+        for s in bad:
+            print(
+                f"[season_vs] Season {s} not found. "
+                f"Valid seasons: {', '.join(str(x) for x in KNOWN_SEASONS)}",
+                file=sys.stderr,
+            )
+        return 1
+
+    if season_a == season_b:
+        print("[season_vs] --a and --b must be different seasons.",
+              file=sys.stderr)
+        return 1
+
+    result = build_vs(season_a, season_b)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(render_text(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- New `tools/season_vs.py` — compares any two Hermitcraft seasons across 5 measurable dimensions
- **Dimensions:** event_count, member_count, build_count, collab_count, highlight_score (sum of top-5 significance scores)
- **Winner logic:** tally dimension wins; tie-break on highlight_score; draw if still tied
- **`winner` field:** `"a"`, `"b"`, or `"tie"` with an integer `winner_season` (null on tie)
- **`rationale` field:** one sentence citing the winning dimension and raw values
- **404-equivalent:** exits 1 with stderr message if either season is out of range (1–11) or both seasons are the same
- Text output: formatted table; JSON output: full structured response
- 74 tests in `tests/test_season_vs.py` (all green)

## Example

```bash
python3 -m tools.season_vs --a 9 --b 10 --json
# → {"season_a":9,"season_b":10,"winner":"a","winner_season":9,
#    "rationale":"Season 9 wins 4/5 dimensions, leading most clearly in documented events (27 vs 13).",
#    "comparison":{"event_count":{"a":27,"b":13,"winner":"a"},...}, ...}
```

## Test plan

- [x] `python3 -m unittest tests.test_season_vs` — 74 tests pass
- [x] `python3 -m tools.season_vs --a 9 --b 10` — text table output
- [x] `python3 -m tools.season_vs --a 7 --b 9 --json` — JSON with winner + rationale
- [x] `--a 999 --b 10` exits 1 with error on stderr
- [x] `--a 9 --b 9` exits 1 (same season)
- [x] Sparse season pairs (S1 vs S2) produce output without crashing

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)