### PR TITLE
[hermitcraft-agent] feat: add limit/offset pagination to list endpoints

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,364 @@
+"""
+Tests for pagination support across tools/timeline.py and tools/hermit_roster.py.
+
+Covers:
+  - The paginate() utility function in both tools (identical contract)
+  - --limit / --offset CLI flags on timeline.py
+  - --limit / --offset CLI flags on hermit_roster.py --all and --season modes
+  - Acceptance criteria from issue #100:
+      * limit default 20, max 100
+      * response includes total, limit, offset
+      * out-of-range offsets return empty items — not errors
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.timeline import paginate as timeline_paginate, main as timeline_main
+from tools.hermit_roster import paginate as roster_paginate, main as roster_main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_timeline(argv: list[str]) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        try:
+            rc = timeline_main(argv)
+        except SystemExit as e:
+            rc = int(e.code) if e.code is not None else 0
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _run_roster(argv: list[str]) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        try:
+            rc = roster_main(argv)
+        except SystemExit as e:
+            rc = int(e.code) if e.code is not None else 0
+    return rc, out.getvalue(), err.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# paginate() — shared contract tested via both importers
+# ---------------------------------------------------------------------------
+
+class TestPaginateContract(unittest.TestCase):
+    """Run identical assertions on both paginate() implementations."""
+
+    def _fns(self):
+        return [timeline_paginate, roster_paginate]
+
+    def test_returns_dict(self):
+        items = list(range(50))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                self.assertIsInstance(fn(items, 10, 0), dict)
+
+    def test_envelope_keys(self):
+        required = {"total", "limit", "offset", "items"}
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(list(range(30)), 10, 0)
+                self.assertTrue(required.issubset(result.keys()))
+
+    def test_total_is_full_length(self):
+        items = list(range(50))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                self.assertEqual(fn(items, 10, 0)["total"], 50)
+
+    def test_items_respects_limit(self):
+        items = list(range(50))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                self.assertEqual(len(fn(items, 5, 0)["items"]), 5)
+
+    def test_items_respects_offset(self):
+        items = list(range(10))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 5, 3)
+                self.assertEqual(result["items"], [3, 4, 5, 6, 7])
+
+    def test_offset_beyond_total_returns_empty(self):
+        items = list(range(10))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 5, 999)
+                self.assertEqual(result["items"], [])
+
+    def test_offset_beyond_total_is_not_error(self):
+        items = list(range(5))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 5, 100)
+                self.assertIsInstance(result, dict)
+                self.assertEqual(result["total"], 5)
+
+    def test_limit_capped_at_max(self):
+        items = list(range(200))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 9999, 0)
+                self.assertLessEqual(result["limit"], 100)
+                self.assertLessEqual(len(result["items"]), 100)
+
+    def test_limit_minimum_is_1(self):
+        items = list(range(10))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 0, 0)
+                self.assertGreaterEqual(result["limit"], 1)
+
+    def test_negative_offset_treated_as_zero(self):
+        items = list(range(10))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 5, -10)
+                self.assertEqual(result["offset"], 0)
+                self.assertEqual(result["items"], items[:5])
+
+    def test_empty_items(self):
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn([], 10, 0)
+                self.assertEqual(result["total"], 0)
+                self.assertEqual(result["items"], [])
+
+    def test_limit_and_offset_stored_in_envelope(self):
+        items = list(range(50))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 7, 3)
+                self.assertEqual(result["limit"], 7)
+                self.assertEqual(result["offset"], 3)
+
+    def test_last_page_has_fewer_items(self):
+        items = list(range(12))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 5, 10)
+                self.assertEqual(len(result["items"]), 2)  # only 2 left
+                self.assertEqual(result["total"], 12)
+
+    def test_exact_last_page(self):
+        items = list(range(10))
+        for fn in self._fns():
+            with self.subTest(fn=fn.__module__):
+                result = fn(items, 5, 5)
+                self.assertEqual(len(result["items"]), 5)
+                self.assertEqual(result["items"], [5, 6, 7, 8, 9])
+
+
+# ---------------------------------------------------------------------------
+# timeline.py -- --limit / --offset CLI flags
+# ---------------------------------------------------------------------------
+
+class TestTimelinePagination(unittest.TestCase):
+
+    def test_limit_returns_envelope(self):
+        rc, out, _ = _run_timeline(["--limit", "5"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIn("total", data)
+        self.assertIn("limit", data)
+        self.assertIn("offset", data)
+        self.assertIn("items", data)
+
+    def test_limit_restricts_items(self):
+        _, out, _ = _run_timeline(["--limit", "3"])
+        data = json.loads(out)
+        self.assertLessEqual(len(data["items"]), 3)
+
+    def test_offset_skips_items(self):
+        _, out1, _ = _run_timeline(["--limit", "5", "--offset", "0"])
+        _, out2, _ = _run_timeline(["--limit", "5", "--offset", "5"])
+        data1 = json.loads(out1)
+        data2 = json.loads(out2)
+        # pages must not overlap
+        ids1 = {e["id"] for e in data1["items"] if "id" in e}
+        ids2 = {e["id"] for e in data2["items"] if "id" in e}
+        self.assertEqual(ids1 & ids2, set())
+
+    def test_offset_only_activates_envelope(self):
+        rc, out, _ = _run_timeline(["--offset", "2"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIn("total", data)
+
+    def test_out_of_range_offset_exit_0(self):
+        rc, out, _ = _run_timeline(["--limit", "10", "--offset", "99999"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertEqual(data["items"], [])
+        self.assertGreater(data["total"], 0)
+
+    def test_total_is_correct(self):
+        # total in paginated mode must equal total events in database
+        _, out_all, _ = _run_timeline(["--pretty"])
+        all_events = json.loads(out_all)
+        _, out_page, _ = _run_timeline(["--limit", "1"])
+        page = json.loads(out_page)
+        self.assertEqual(page["total"], len(all_events))
+
+    def test_limit_100_is_allowed(self):
+        rc, _, _ = _run_timeline(["--limit", "100"])
+        self.assertEqual(rc, 0)
+
+    def test_limit_exceeding_max_is_capped(self):
+        _, out, _ = _run_timeline(["--limit", "99999"])
+        data = json.loads(out)
+        self.assertLessEqual(data["limit"], 100)
+
+    def test_pagination_with_season_filter(self):
+        _, out, _ = _run_timeline(["--season", "9", "--limit", "3"])
+        data = json.loads(out)
+        self.assertIn("total", data)
+        for item in data["items"]:
+            self.assertEqual(item.get("season"), 9)
+
+    def test_pagination_with_type_filter(self):
+        _, out, _ = _run_timeline(["--type", "milestone", "--limit", "5"])
+        data = json.loads(out)
+        for item in data["items"]:
+            self.assertEqual(item.get("type"), "milestone")
+
+    def test_envelope_is_valid_json(self):
+        _, out, _ = _run_timeline(["--limit", "10"])
+        self.assertIsInstance(json.loads(out), dict)
+
+    def test_no_pagination_flags_still_works(self):
+        # without --limit/--offset, old NDJSON behaviour is preserved
+        rc, out, _ = _run_timeline(["--season", "9"])
+        self.assertEqual(rc, 0)
+        # NDJSON: each line should be a valid JSON object
+        for line in out.strip().splitlines():
+            obj = json.loads(line)
+            self.assertIsInstance(obj, dict)
+
+    def test_combined_filters_and_pagination(self):
+        _, out, _ = _run_timeline(
+            ["--season", "9", "--type", "milestone", "--limit", "2"]
+        )
+        data = json.loads(out)
+        self.assertIn("total", data)
+        for item in data["items"]:
+            self.assertEqual(item.get("season"), 9)
+            self.assertEqual(item.get("type"), "milestone")
+
+
+# ---------------------------------------------------------------------------
+# hermit_roster.py -- --all mode pagination
+# ---------------------------------------------------------------------------
+
+class TestRosterAllPagination(unittest.TestCase):
+
+    def test_limit_returns_envelope(self):
+        rc, out, _ = _run_roster(["--all", "--json", "--limit", "5"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIn("total", data)
+        self.assertIn("limit", data)
+        self.assertIn("offset", data)
+        self.assertIn("items", data)
+
+    def test_limit_restricts_items(self):
+        _, out, _ = _run_roster(["--all", "--json", "--limit", "3"])
+        data = json.loads(out)
+        self.assertLessEqual(len(data["items"]), 3)
+
+    def test_total_reflects_full_roster(self):
+        _, out_all, _ = _run_roster(["--all", "--json"])
+        all_data = json.loads(out_all)
+        _, out_page, _ = _run_roster(["--all", "--json", "--limit", "2"])
+        page = json.loads(out_page)
+        self.assertEqual(page["total"], all_data["hermit_count"])
+
+    def test_offset_skips_hermits(self):
+        _, out1, _ = _run_roster(["--all", "--json", "--limit", "5", "--offset", "0"])
+        _, out2, _ = _run_roster(["--all", "--json", "--limit", "5", "--offset", "5"])
+        names1 = {h["name"] for h in json.loads(out1)["items"]}
+        names2 = {h["name"] for h in json.loads(out2)["items"]}
+        self.assertEqual(names1 & names2, set())
+
+    def test_out_of_range_offset_empty_items(self):
+        rc, out, _ = _run_roster(["--all", "--json", "--limit", "5", "--offset", "9999"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertEqual(data["items"], [])
+
+    def test_no_pagination_preserves_old_format(self):
+        _, out, _ = _run_roster(["--all", "--json"])
+        data = json.loads(out)
+        self.assertIn("hermit_count", data)
+        self.assertIn("hermits", data)
+
+    def test_limit_without_json_still_exits_0(self):
+        # text mode ignores pagination flags gracefully
+        rc, _, _ = _run_roster(["--all", "--limit", "5"])
+        self.assertEqual(rc, 0)
+
+    def test_envelope_limit_stored(self):
+        _, out, _ = _run_roster(["--all", "--json", "--limit", "7"])
+        data = json.loads(out)
+        self.assertEqual(data["limit"], 7)
+
+    def test_envelope_offset_stored(self):
+        _, out, _ = _run_roster(["--all", "--json", "--limit", "5", "--offset", "2"])
+        data = json.loads(out)
+        self.assertEqual(data["offset"], 2)
+
+
+# ---------------------------------------------------------------------------
+# hermit_roster.py -- --season mode pagination
+# ---------------------------------------------------------------------------
+
+class TestRosterSeasonPagination(unittest.TestCase):
+
+    def test_season_limit_returns_envelope(self):
+        rc, out, _ = _run_roster(["--season", "9", "--json", "--limit", "3"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertIn("total", data)
+        self.assertIn("items", data)
+
+    def test_season_envelope_contains_season_key(self):
+        _, out, _ = _run_roster(["--season", "9", "--json", "--limit", "3"])
+        data = json.loads(out)
+        self.assertEqual(data["season"], 9)
+
+    def test_season_items_are_hermit_dicts(self):
+        _, out, _ = _run_roster(["--season", "9", "--json", "--limit", "5"])
+        data = json.loads(out)
+        for item in data["items"]:
+            self.assertIn("name", item)
+            self.assertIn("seasons", item)
+
+    def test_season_out_of_range_offset_empty(self):
+        rc, out, _ = _run_roster(["--season", "9", "--json", "--limit", "5", "--offset", "9999"])
+        self.assertEqual(rc, 0)
+        data = json.loads(out)
+        self.assertEqual(data["items"], [])
+
+    def test_season_no_pagination_preserves_old_format(self):
+        _, out, _ = _run_roster(["--season", "9", "--json"])
+        data = json.loads(out)
+        self.assertIn("season", data)
+        self.assertIn("hermit_count", data)
+        self.assertIn("hermits", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/hermit_roster.py
+++ b/tools/hermit_roster.py
@@ -45,6 +45,30 @@ from pathlib import Path
 _HERMITS_DIR = Path(__file__).parent.parent / "knowledge" / "hermits"
 KNOWN_SEASONS: list[int] = list(range(1, 12))  # seasons 1–11
 
+_DEFAULT_LIMIT = 20
+_MAX_LIMIT = 100
+
+
+def paginate(items: list, limit: int, offset: int) -> dict:
+    """
+    Return a pagination envelope for *items*.
+
+    Response shape::
+
+        {"total": <int>, "limit": <int>, "offset": <int>, "items": [...]}
+
+    Limit is capped at _MAX_LIMIT.  An offset beyond the total returns an
+    empty items list (not an error).
+    """
+    limit = max(1, min(limit, _MAX_LIMIT))
+    offset = max(0, offset)
+    return {
+        "total": len(items),
+        "limit": limit,
+        "offset": offset,
+        "items": items[offset: offset + limit],
+    }
+
 
 # ---------------------------------------------------------------------------
 # Frontmatter parser (no external deps)
@@ -403,6 +427,23 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Output as JSON",
     )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            f"Page size for list results (default {_DEFAULT_LIMIT}, "
+            f"max {_MAX_LIMIT}). Activates pagination envelope in JSON output."
+        ),
+    )
+    p.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Zero-based starting index for pagination (default 0).",
+    )
     return p
 
 
@@ -412,12 +453,20 @@ def main(argv: list[str] | None = None) -> int:
 
     roster = load_roster()
 
+    # Determine if pagination was explicitly requested
+    use_pagination = args.limit is not None or args.offset != 0
+    limit = args.limit if args.limit is not None else _DEFAULT_LIMIT
+
     # ── --all ──────────────────────────────────────────────────────────────
     if args.all:
         entries = all_hermits(roster)
         if args.json:
-            print(json.dumps({"hermit_count": len(entries), "hermits": entries},
-                             indent=2))
+            if use_pagination:
+                page = paginate(entries, limit=limit, offset=args.offset)
+                print(json.dumps(page, indent=2))
+            else:
+                print(json.dumps({"hermit_count": len(entries), "hermits": entries},
+                                 indent=2))
         else:
             print(format_all_text(entries))
         return 0
@@ -426,11 +475,16 @@ def main(argv: list[str] | None = None) -> int:
     if args.season is not None:
         active = hermits_for_season(roster, args.season)
         if args.json:
-            print(json.dumps(
-                {"season": args.season, "hermit_count": len(active),
-                 "hermits": active},
-                indent=2,
-            ))
+            if use_pagination:
+                page = paginate(active, limit=limit, offset=args.offset)
+                page["season"] = args.season
+                print(json.dumps(page, indent=2))
+            else:
+                print(json.dumps(
+                    {"season": args.season, "hermit_count": len(active),
+                     "hermits": active},
+                    indent=2,
+                ))
         else:
             print(format_season_text(args.season, active))
         return 0

--- a/tools/timeline.py
+++ b/tools/timeline.py
@@ -15,19 +15,28 @@ Usage
   python3 tools/timeline.py --season 6 --hermit Iskall85
   python3 tools/timeline.py --season 8 --type milestone
   python3 tools/timeline.py --stats                     # summary stats
+  python3 tools/timeline.py --limit 10 --offset 20     # paginated slice
 
 Filters can be combined; all supplied filters must match (AND logic).
 Keyword search checks title, description, and hermit names.
 
+Pagination
+----------
+Use --limit N (default 20, max 100) and --offset N (default 0) to page
+through results.  When either flag is given the output is a JSON envelope:
+  {"total": <int>, "limit": <int>, "offset": <int>, "items": [...]}
+An offset beyond the total returns an empty items array (not an error).
+
 Output
 ------
-Always newline-delimited JSON objects (one per line) so results pipe
-cleanly into `jq`.  Use --pretty for indented multi-line JSON array.
+Without pagination flags: newline-delimited JSON objects (one per line)
+so results pipe cleanly into `jq`.  Use --pretty for indented JSON array.
+With pagination flags: always a single JSON envelope object.
 
 Exit codes
 ----------
-  0  success (≥1 results)
-  1  no events match the given filters
+  0  success (≥1 results, or paginated response)
+  1  no events match the given filters (non-paginated mode only)
   2  bad arguments or events file not found
 """
 
@@ -38,6 +47,38 @@ import sys
 from pathlib import Path
 
 EVENTS_FILE = Path(__file__).parent.parent / "knowledge" / "timelines" / "events.json"
+
+_DEFAULT_LIMIT = 20
+_MAX_LIMIT = 100
+
+
+def paginate(items: list, limit: int, offset: int) -> dict:
+    """
+    Return a pagination envelope for *items*.
+
+    Args:
+        items:   The full (already-filtered) list to page.
+        limit:   Maximum number of items to return (capped at _MAX_LIMIT).
+        offset:  Zero-based starting index.  Values beyond len(items) return
+                 an empty ``items`` list — never an error.
+
+    Returns::
+
+        {
+            "total":  <int>,   # total number of matching items before slicing
+            "limit":  <int>,   # effective limit (≤ _MAX_LIMIT)
+            "offset": <int>,   # effective offset (≥ 0)
+            "items":  [...]    # the sliced page
+        }
+    """
+    limit = max(1, min(limit, _MAX_LIMIT))
+    offset = max(0, offset)
+    return {
+        "total": len(items),
+        "limit": limit,
+        "offset": offset,
+        "items": items[offset: offset + limit],
+    }
 
 VALID_TYPES = {"build", "collab", "game", "lore", "meta", "milestone"}
 
@@ -167,6 +208,17 @@ def main(argv: list[str] | None = None) -> int:
         "--pretty", action="store_true",
         help="Output a pretty-printed JSON array instead of NDJSON",
     )
+    parser.add_argument(
+        "--limit", type=int, default=None, metavar="N",
+        help=(
+            f"Page size: max items to return (default {_DEFAULT_LIMIT}, "
+            f"max {_MAX_LIMIT}). Activates pagination envelope output."
+        ),
+    )
+    parser.add_argument(
+        "--offset", type=int, default=0, metavar="N",
+        help="Zero-based starting index for pagination (default 0).",
+    )
 
     args = parser.parse_args(argv)
     events = load_events()
@@ -182,6 +234,14 @@ def main(argv: list[str] | None = None) -> int:
         event_type=args.event_type,
         search=args.search,
     )
+
+    # Pagination mode: --limit or non-zero --offset activates the envelope
+    use_pagination = args.limit is not None or args.offset != 0
+    if use_pagination:
+        limit = args.limit if args.limit is not None else _DEFAULT_LIMIT
+        page = paginate(results, limit=limit, offset=args.offset)
+        print(json.dumps(page, indent=2))
+        return 0
 
     if not results:
         sys.stderr.write(


### PR DESCRIPTION
## Summary

- Added `paginate(items, limit, offset)` utility to `tools/timeline.py` and `tools/hermit_roster.py`
- **Response envelope:** `{"total": N, "limit": L, "offset": O, "items": [...]}`
- **`timeline.py`:** new `--limit N` (default 20, max 100) and `--offset N` flags; activates JSON envelope; without flags, existing NDJSON streaming behaviour is preserved
- **`hermit_roster.py`:** `--limit` / `--offset` work with `--all --json` and `--season --json` modes; non-JSON text mode ignores pagination flags gracefully
- Out-of-range offset returns `{"items": [], "total": N}` — exit 0, never an error
- Limit capped at 100; negative offset treated as 0
- 41 tests in `tests/test_pagination.py` covering the shared contract and both tools
- All 146 existing timeline + roster tests still pass

## Test plan

- [x] `python3 -m tools.timeline --limit 5 --offset 0` → 5 events, total=73
- [x] `python3 -m tools.timeline --limit 5 --offset 999` → empty items, exit 0
- [x] `python3 -m tools.hermit_roster --all --json --limit 5` → 5 hermits, total=27
- [x] `python3 -m tools.hermit_roster --season 9 --json --limit 3 --offset 0` → paginated season roster
- [x] `--limit 99999` → limit capped at 100 in response

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)