### PR TITLE
[hermitcraft-agent] feat: add --interactive REPL to search tool

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,9 +16,12 @@ from tools.search import (
     HERMITS_DIR,
     SEASONS_DIR,
     VIDEO_EVENTS_FILE,
+    _REPL_HELP,
+    _build_repl_parser,
     _count_matches,
     _tokenise_query,
     format_search_results,
+    interactive_session,
     make_snippet,
     run_search,
     score_result,
@@ -477,6 +480,264 @@ class TestDataIntegrity(unittest.TestCase):
         self.assertGreater(len(results), 0)
 
 
+# ---------------------------------------------------------------------------
+# _build_repl_parser
+# ---------------------------------------------------------------------------
+
+class TestBuildReplParser(unittest.TestCase):
+
+    def _parse(self, line: str):
+        import shlex
+        parser = _build_repl_parser()
+        args, _ = parser.parse_known_args(shlex.split(line))
+        return args
+
+    def test_plain_words_become_query(self):
+        args = self._parse("boatem hole")
+        self.assertEqual(args.query_words, ["boatem", "hole"])
+
+    def test_season_flag_parsed(self):
+        args = self._parse("grian --season 9")
+        self.assertEqual(args.season, 9)
+
+    def test_limit_flag_parsed(self):
+        args = self._parse("grian --limit 5")
+        self.assertEqual(args.limit, 5)
+
+    def test_sources_flag_parsed(self):
+        args = self._parse("grian --sources events hermits")
+        self.assertIn("events", args.sources)
+        self.assertIn("hermits", args.sources)
+
+    def test_json_flag_parsed(self):
+        args = self._parse("grian --json")
+        self.assertTrue(args.as_json)
+
+    def test_default_limit_is_20(self):
+        args = self._parse("grian")
+        self.assertEqual(args.limit, 20)
+
+    def test_default_season_is_none(self):
+        args = self._parse("grian")
+        self.assertIsNone(args.season)
+
+    def test_default_json_is_false(self):
+        args = self._parse("grian")
+        self.assertFalse(args.as_json)
+
+    def test_mixed_query_and_flags(self):
+        args = self._parse("prank grian --season 6 --limit 3")
+        self.assertEqual(args.query_words, ["prank", "grian"])
+        self.assertEqual(args.season, 6)
+        self.assertEqual(args.limit, 3)
+
+
+# ---------------------------------------------------------------------------
+# interactive_session
+# ---------------------------------------------------------------------------
+
+class TestInteractiveSession(unittest.TestCase):
+    """Test the REPL by mocking builtins.input."""
+
+    def _run_session(self, inputs: list[str]) -> tuple[int, str, str]:
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        from unittest.mock import patch
+
+        input_iter = iter(inputs)
+
+        def fake_input(prompt=""):
+            try:
+                return next(input_iter)
+            except StopIteration:
+                raise EOFError()
+
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            with patch("builtins.input", side_effect=fake_input):
+                with patch("tools.search._readline_setup", return_value=None):
+                    rc = interactive_session()
+        return rc, out_buf.getvalue(), err_buf.getvalue()
+
+    def test_quit_exits_0(self):
+        rc, _, _ = self._run_session(["quit"])
+        self.assertEqual(rc, 0)
+
+    def test_exit_exits_0(self):
+        rc, _, _ = self._run_session(["exit"])
+        self.assertEqual(rc, 0)
+
+    def test_eof_exits_0(self):
+        rc, _, _ = self._run_session([])
+        self.assertEqual(rc, 0)
+
+    def test_help_prints_flags(self):
+        _, out, _ = self._run_session(["help", "quit"])
+        self.assertIn("--season", out)
+        self.assertIn("--limit", out)
+
+    def test_question_mark_shows_help(self):
+        _, out, _ = self._run_session(["?", "quit"])
+        self.assertIn("--season", out)
+
+    def test_empty_line_no_crash(self):
+        rc, _, _ = self._run_session(["", "quit"])
+        self.assertEqual(rc, 0)
+
+    def test_whitespace_line_no_crash(self):
+        rc, _, _ = self._run_session(["   ", "quit"])
+        self.assertEqual(rc, 0)
+
+    def test_valid_query_produces_output(self):
+        _, out, _ = self._run_session(["grian", "quit"])
+        self.assertGreater(len(out), 0)
+
+    def test_valid_query_shows_term_in_output(self):
+        _, out, _ = self._run_session(["boatem", "quit"])
+        self.assertTrue("boatem" in out.lower() or "result" in out.lower())
+
+    def test_season_flag_in_query(self):
+        rc, _, _ = self._run_session(["grian --season 9", "quit"])
+        self.assertEqual(rc, 0)
+
+    def test_limit_flag_in_query(self):
+        rc, _, _ = self._run_session(["grian --limit 2", "quit"])
+        self.assertEqual(rc, 0)
+
+    def test_json_flag_produces_json(self):
+        _, out, _ = self._run_session(["grian --json", "quit"])
+        # Find the { that starts the JSON block
+        idx = out.find("{")
+        if idx != -1:
+            data = json.loads(out[idx:out.rindex("}") + 1])
+            self.assertIn("query", data)
+
+    def test_unrecognised_flag_warns_stderr(self):
+        _, _, err = self._run_session(["grian --badflagnobodyuses", "quit"])
+        self.assertIsInstance(err, str)
+
+    def test_ctrl_c_mid_line_continues(self):
+        from unittest.mock import patch
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+
+        call_count = [0]
+
+        def fake_input_kb(prompt=""):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise KeyboardInterrupt()
+            if call_count[0] == 2:
+                return "quit"
+            raise EOFError()
+
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            with patch("builtins.input", side_effect=fake_input_kb):
+                with patch("tools.search._readline_setup", return_value=None):
+                    rc = interactive_session()
+
+        self.assertEqual(rc, 0)
+        self.assertGreaterEqual(call_count[0], 2)
+
+    def test_multiple_queries_in_session(self):
+        rc, out, _ = self._run_session(["grian", "mumbo", "quit"])
+        self.assertEqual(rc, 0)
+        self.assertIn("grian", out.lower())
+
+    def test_no_query_words_warns_stderr(self):
+        _, _, err = self._run_session(["--season 9", "quit"])
+        self.assertIsInstance(err, str)
+
+    def test_banner_printed_on_start(self):
+        _, out, _ = self._run_session(["quit"])
+        self.assertIn("search", out.lower())
+
+    def test_quit_case_insensitive(self):
+        rc, _, _ = self._run_session(["QUIT"])
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# CLI — --interactive flag
+# ---------------------------------------------------------------------------
+
+class TestCLIInteractive(unittest.TestCase):
+
+    def _run(self, argv: list[str], inputs: list[str] = None) -> tuple[int, str, str]:
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        from unittest.mock import patch
+        from tools.search import main as search_main
+
+        inputs = inputs or []
+        input_iter = iter(inputs)
+
+        def fake_input(prompt=""):
+            try:
+                return next(input_iter)
+            except StopIteration:
+                raise EOFError()
+
+        out_buf, err_buf = io.StringIO(), io.StringIO()
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            with patch("builtins.input", side_effect=fake_input):
+                with patch("tools.search._readline_setup", return_value=None):
+                    try:
+                        rc = search_main(argv)
+                    except SystemExit as e:
+                        rc = int(e.code) if e.code is not None else 0
+        return rc, out_buf.getvalue(), err_buf.getvalue()
+
+    def test_interactive_flag_exits_0(self):
+        rc, _, _ = self._run(["--interactive"], inputs=["quit"])
+        self.assertEqual(rc, 0)
+
+    def test_interactive_short_flag(self):
+        rc, _, _ = self._run(["-i"], inputs=["quit"])
+        self.assertEqual(rc, 0)
+
+    def test_no_query_no_interactive_exits_nonzero(self):
+        rc, _, _ = self._run([])
+        self.assertNotEqual(rc, 0)
+
+    def test_interactive_produces_output(self):
+        _, out, _ = self._run(["--interactive"], inputs=["boatem", "quit"])
+        self.assertGreater(len(out.strip()), 0)
+
+    def test_interactive_handles_eof_gracefully(self):
+        rc, _, _ = self._run(["--interactive"], inputs=[])
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# _REPL_HELP constant
+# ---------------------------------------------------------------------------
+
+class TestReplHelp(unittest.TestCase):
+
+    def test_help_is_string(self):
+        self.assertIsInstance(_REPL_HELP, str)
+
+    def test_help_contains_season_flag(self):
+        self.assertIn("--season", _REPL_HELP)
+
+    def test_help_contains_limit_flag(self):
+        self.assertIn("--limit", _REPL_HELP)
+
+    def test_help_contains_sources_flag(self):
+        self.assertIn("--sources", _REPL_HELP)
+
+    def test_help_contains_quit_instruction(self):
+        self.assertIn("quit", _REPL_HELP.lower())
+
+    def test_help_contains_json_flag(self):
+        self.assertIn("--json", _REPL_HELP)
+
+    def test_help_nonempty(self):
+        self.assertGreater(len(_REPL_HELP), 20)
+
+
 if __name__ == "__main__":
     import traceback
 
@@ -492,6 +753,10 @@ if __name__ == "__main__":
         ("format_results",    unittest.TestLoader().loadTestsFromTestCase(TestFormatSearchResults)),
         ("CLI",               unittest.TestLoader().loadTestsFromTestCase(TestCLI)),
         ("data_integrity",    unittest.TestLoader().loadTestsFromTestCase(TestDataIntegrity)),
+        ("repl_parser",       unittest.TestLoader().loadTestsFromTestCase(TestBuildReplParser)),
+        ("interactive",       unittest.TestLoader().loadTestsFromTestCase(TestInteractiveSession)),
+        ("cli_interactive",   unittest.TestLoader().loadTestsFromTestCase(TestCLIInteractive)),
+        ("repl_help",         unittest.TestLoader().loadTestsFromTestCase(TestReplHelp)),
     ]
 
     passed = failed = 0

--- a/tools/search.py
+++ b/tools/search.py
@@ -13,6 +13,31 @@ Usage
   python3 tools/search.py --query "Decked Out" --season 7
   python3 tools/search.py --query "redstone" --sources events hermits
   python3 tools/search.py --query "mycelium" --limit 5
+  python3 tools/search.py --interactive        # launch REPL
+
+Interactive REPL
+----------------
+  $ python3 tools/search.py --interactive
+
+  Hermitcraft Search > boatem hole
+    3 results for "boatem hole" …
+
+  Hermitcraft Search > prank grian --season 6
+    5 results …
+
+  Hermitcraft Search > help
+    (lists available flags)
+
+  Hermitcraft Search > quit
+
+  REPL flags (optional, per-query):
+    --season N        Restrict to a specific season
+    --sources S ...   Which sources to search (events hermits seasons)
+    --limit N         Max results (default 20)
+    --json            Output as JSON
+
+  Session history persisted to ~/.hermitcraft_search_history (readline).
+  Ctrl-D or type 'quit' / 'exit' to leave.
 
 Sources searched (default: all)
 ---------------------------------
@@ -42,6 +67,7 @@ Exit codes
 import argparse
 import json
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -383,6 +409,169 @@ def format_search_results(query: str, results: list[dict]) -> str:
 # CLI
 # ---------------------------------------------------------------------------
 
+_REPL_HISTORY_FILE = Path.home() / ".hermitcraft_search_history"
+
+_REPL_HELP = """
+Interactive search flags (append to your query on the same line):
+  --season N          Restrict to a specific season number (1–11)
+  --sources S [S...]  Limit sources: events, hermits, seasons
+  --limit N           Max results (default 20)
+  --json              Output as JSON instead of text
+
+Special commands:
+  help                Show this help
+  quit / exit         Exit the REPL (also Ctrl-D)
+
+Examples:
+  Hermitcraft Search > boatem hole
+  Hermitcraft Search > prank grian --season 6
+  Hermitcraft Search > decked out --sources events --limit 5
+  Hermitcraft Search > mycelium resistance --json
+""".strip()
+
+
+def _build_repl_parser() -> argparse.ArgumentParser:
+    """Argument parser used inside the REPL — query is positional, all flags optional."""
+    p = argparse.ArgumentParser(
+        prog="search",
+        description="Hermitcraft interactive search",
+        add_help=False,  # we handle 'help' ourselves
+    )
+    p.add_argument(
+        "query_words",
+        nargs="*",
+        help="Search terms",
+    )
+    p.add_argument(
+        "--sources",
+        nargs="+",
+        choices=list(ALL_SOURCES),
+        default=list(ALL_SOURCES),
+        metavar="SOURCE",
+    )
+    p.add_argument(
+        "--season",
+        type=int,
+        metavar="N",
+        default=None,
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        metavar="N",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+    )
+    return p
+
+
+def _readline_setup() -> None:
+    """Configure readline with history persistence (best-effort; no crash if unavailable)."""
+    try:
+        import readline  # noqa: PLC0415  # not available on all platforms
+        if _REPL_HISTORY_FILE.exists():
+            readline.read_history_file(str(_REPL_HISTORY_FILE))
+        readline.set_history_length(500)
+        import atexit
+        atexit.register(readline.write_history_file, str(_REPL_HISTORY_FILE))
+    except (ImportError, OSError):
+        pass
+
+
+def interactive_session() -> int:
+    """
+    Run the interactive search REPL.
+
+    Each input line is parsed by ``_build_repl_parser()``: leading words
+    before the first ``--flag`` are treated as the query; flag tokens are
+    handled exactly as in the CLI.
+
+    Returns 0 on clean exit (quit / Ctrl-D), 1 if an unrecoverable error
+    occurs.
+    """
+    _readline_setup()
+    repl_parser = _build_repl_parser()
+
+    prompt = "Hermitcraft Search > "
+    print("Hermitcraft interactive search  (type 'help' for flags, 'quit' to exit)")
+
+    while True:
+        try:
+            raw = input(prompt)
+        except EOFError:
+            # Ctrl-D
+            print()  # newline after prompt
+            break
+        except KeyboardInterrupt:
+            # Ctrl-C mid-line: clear the line and continue
+            print()
+            continue
+
+        line = raw.strip()
+        if not line:
+            continue
+
+        # Special commands
+        lower = line.lower()
+        if lower in ("quit", "exit", "q"):
+            break
+        if lower in ("help", "?"):
+            print(_REPL_HELP)
+            continue
+
+        # Parse query + optional flags
+        try:
+            tokens = shlex.split(line)
+        except ValueError as exc:
+            sys.stderr.write(f"  [search] Parse error: {exc}\n")
+            continue
+
+        try:
+            args, unknown = repl_parser.parse_known_args(tokens)
+        except SystemExit:
+            # argparse called sys.exit on bad flag; absorb it
+            sys.stderr.write("  [search] Bad flag. Type 'help' to see valid options.\n")
+            continue
+
+        if unknown:
+            sys.stderr.write(
+                f"  [search] Unrecognised option(s): {' '.join(unknown)}.  "
+                "Type 'help' for flags.\n"
+            )
+            continue
+
+        query = " ".join(args.query_words).strip()
+        if not query:
+            sys.stderr.write("  [search] Please enter search terms.  Type 'help' for usage.\n")
+            continue
+
+        # Run the search
+        results = run_search(
+            query=query,
+            sources=args.sources,
+            season_filter=args.season,
+            limit=args.limit,
+        )
+
+        if args.as_json:
+            payload = {
+                "query": query,
+                "sources": args.sources,
+                "season_filter": args.season,
+                "result_count": len(results),
+                "results": results,
+            }
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+        else:
+            print(format_search_results(query, results))
+
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="search",
@@ -394,8 +583,16 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=__doc__,
     )
     parser.add_argument(
+        "--interactive", "-i",
+        action="store_true",
+        help=(
+            "Launch an interactive search REPL.  "
+            "Session history is persisted to ~/.hermitcraft_search_history."
+        ),
+    )
+    parser.add_argument(
         "--query", "-q",
-        required=True,
+        required=False,
         metavar="KEYWORDS",
         help="Search terms (space-separated, OR logic across terms).",
     )
@@ -435,6 +632,15 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    # Interactive REPL mode
+    if args.interactive:
+        return interactive_session()
+
+    # Non-interactive mode requires --query
+    if not args.query:
+        sys.stderr.write("[search] --query is required (or use --interactive).\n")
+        return 2
 
     if args.limit < 1:
         sys.stderr.write("[search] --limit must be ≥ 1\n")


### PR DESCRIPTION
## Summary

- New `--interactive` / `-i` flag on `tools/search.py` launches a readline-backed REPL
- Each input line is parsed identically to the CLI: leading words = query, optional `--season`, `--sources`, `--limit`, `--json` flags appended inline
- Session history persisted to `~/.hermitcraft_search_history` (readline; gracefully skipped if unavailable)
- `help` / `?` prints flag reference; `quit` / `exit` / Ctrl-D exit cleanly
- Ctrl-C mid-line clears the line and continues without crashing
- 39 new tests in `tests/test_search.py`; total 118 (all green)

## Example session

```
$ python3 -m tools.search --interactive

Hermitcraft interactive search  (type 'help' for flags, 'quit' to exit)
Hermitcraft Search > boatem hole
  ════════════════════ HERMITCRAFT SEARCH: "boatem hole" ════════════════════
  3 results found
  ...

Hermitcraft Search > prank grian --season 6
  ...

Hermitcraft Search > help
  Interactive search flags (append to your query on the same line):
    --season N        Restrict to a specific season number (1–11)
    ...

Hermitcraft Search > quit
```

## Test plan

- [x] `python3 -m unittest tests.test_search` — 118 tests pass
- [x] `python3 -m tools.search --interactive` then type queries
- [x] `python3 -m tools.search --interactive` → Ctrl-D exits cleanly
- [x] `python3 -m tools.search --interactive` → Ctrl-C mid-line continues
- [x] `help` shows all flags; `quit` exits
- [x] `--query` still required in non-interactive mode

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)